### PR TITLE
Clean shared folder - yemot

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -11,6 +11,7 @@ import { AuthModule } from '@shared/auth/auth.module';
 import { YemotModule } from '@shared/utils/yemot/yemot.module';
 // import { yemotProcessorProvider } from 'src/yemot.processor';
 import yemotChain from './yemot/yemot.chain';
+import { YemotRequestImpl } from './yemot/yemot.request.impl';
 import { MailSendModule } from '@shared/utils/mail/mail-send.module';
 import { EntitiesModule } from './entities.module';
 import { getPinoConfig } from '@shared/config/pino.config';
@@ -24,7 +25,7 @@ import { getPinoConfig } from '@shared/config/pino.config';
     MailSendModule,
     EntitiesModule,
     AuthModule,
-    YemotModule.register(yemotChain)
+    YemotModule.register(yemotChain, YemotRequestImpl),
   ],
   controllers: [AppController],
   providers: [

--- a/server/src/yemot/__tests__/yemotRequestImp.spec.ts
+++ b/server/src/yemot/__tests__/yemotRequestImp.spec.ts
@@ -1,0 +1,133 @@
+import { User } from "@shared/entities/User.entity";
+import { YemotCall } from "@shared/entities/YemotCall.entity";
+import { getCurrentHebrewYear } from "@shared/utils/entity/year.util";
+import { getMockDataSource, MockYemotRequest } from "@shared/utils/yemot/__tests__/yemot.interface.spec";
+import { YemotRequest } from "@shared/utils/yemot/yemot.interface";
+import { AttReport } from "src/db/entities/AttReport.entity";
+import { Grade } from "src/db/entities/Grade.entity";
+import { DataSource, In } from "typeorm";
+import { YemotRequestImpl } from "../yemot.request.impl";
+
+describe('YemotRequest', () => {
+  let dataSource: DataSource;
+  let yemotRequest: YemotRequestImpl;
+  let activeCall: YemotCall;
+
+  beforeEach(() => {
+    dataSource = getMockDataSource();
+    activeCall = new YemotCall();
+    activeCall.userId = 1;
+    yemotRequest = new YemotRequestImpl(activeCall, dataSource);
+  });
+
+  it('should return the correct userId from the active call', () => {
+    const result = yemotRequest.getUserId();
+    expect(result).toBe(1);
+  });
+
+  it('should return user permissions for the given userId', async () => {
+    const user = { id: 1, permissions: ["READ", "WRITE"] };
+
+    // Mock the database call
+    jest.spyOn(yemotRequest, 'getUser').mockResolvedValue(user as User);
+
+    const result = await yemotRequest.getUserPermissions();
+    expect(result).toEqual(["READ", "WRITE"]);
+  });
+
+  it('should get lesson by lesson id', async () => {
+    const lessonId = 1;
+    const lesson = { id: 1 };
+
+    jest.spyOn(dataSource.getRepository(YemotCall), 'findOneBy').mockResolvedValue(lesson as YemotCall);
+
+    const result = await yemotRequest.getLessonFromLessonId(lessonId);
+    expect(result).toEqual(lesson);
+  });
+
+  it('should get klass by klass id', async () => {
+    const klassId = 1;
+    const klass = { id: 1 };
+
+    const mock = jest.spyOn(dataSource.getRepository(YemotCall), 'findOneBy').mockResolvedValue(klass as YemotCall);
+
+    const result = await yemotRequest.getKlassByKlassId(null, klassId);
+    expect(result).toEqual(klass);
+    expect(mock).toHaveBeenCalledWith({ id: klassId });
+  });
+
+  it('should get klass by key', async () => {
+    const klassKey = 1;
+    const klass = { id: 1 };
+
+    const mock = jest.spyOn(dataSource.getRepository(YemotCall), 'findOneBy').mockResolvedValue(klass as YemotCall);
+
+    const result = await yemotRequest.getKlassByKlassId(klassKey, null);
+    expect(result).toEqual(klass);
+    expect(mock).toHaveBeenCalledWith({ key: klassKey, userId: 1, year: getCurrentHebrewYear() });
+  });
+
+  it('should get teacher by phone', async () => {
+    const phone = '1234567890';
+    const teacher = { id: 1 };
+
+    jest.spyOn(dataSource.getRepository(YemotCall), 'findOne').mockResolvedValue(teacher as YemotCall);
+
+    const result = await yemotRequest.getTeacherByPhone(phone);
+    expect(result).toEqual(teacher);
+  });
+
+  it('should get students by klass id', async () => {
+    const klassId = 1;
+    const students = [{ id: 1 }, { id: 2 }];
+
+    jest.spyOn(dataSource.getRepository(YemotCall), 'find').mockResolvedValue(students.map(student => ({ student })) as any[] as YemotCall[]);
+
+    const result = await yemotRequest.getStudentsByKlassId(klassId);
+    expect(result).toEqual(students);
+  });
+
+  it('should save report', async () => {
+    const reportData = { id: 1 };
+    const type = 'att';
+
+    jest.spyOn(yemotRequest, 'getExistingAttReports').mockResolvedValue([]);
+    jest.spyOn(yemotRequest, 'getExistingGradeReports').mockResolvedValue([]);
+    jest.spyOn(dataSource.getRepository(AttReport), 'create').mockResolvedValue(reportData as never);
+
+    const result = await yemotRequest.saveReport(reportData as AttReport, type);
+    expect(result).toEqual(reportData);
+
+    expect(dataSource.getRepository).toHaveBeenCalledWith(AttReport);
+  });
+
+  it('should get existing att reports', async () => {
+    jest.spyOn(dataSource.getRepository(AttReport), 'findBy').mockResolvedValue([]);
+
+    const result = await yemotRequest.getExistingAttReports(null, null, null);
+    expect(result).toEqual([]);
+  });
+
+  it('should get existing grade reports', async () => {
+    jest.spyOn(dataSource.getRepository(Grade), 'findBy').mockResolvedValue([]);
+
+    const result = await yemotRequest.getExistingGradeReports(null, null, null);
+    expect(result).toEqual([]);
+  });
+
+  it('should delete existing reports', async () => {
+    const existingReports = [{ id: 1 }, { id: 2 }];
+
+    const attMock = jest.spyOn(dataSource.getRepository(AttReport), 'delete').mockResolvedValue(null);
+    const gradeMock = jest.spyOn(dataSource.getRepository(Grade), 'delete').mockResolvedValue(null);
+
+    const result = await yemotRequest.deleteExistingReports(existingReports as (AttReport | Grade)[], 'att');
+    expect(result).toEqual(undefined);
+    expect(attMock).toHaveBeenCalledWith({ id: In([1, 2]) });
+
+    const result2 = await yemotRequest.deleteExistingReports(existingReports as (AttReport | Grade)[], 'grade');
+    expect(result2).toEqual(undefined);
+    expect(gradeMock).toHaveBeenCalledWith({ id: In([1, 2]) });
+  });
+});
+

--- a/server/src/yemot/yemot.request.impl.ts
+++ b/server/src/yemot/yemot.request.impl.ts
@@ -1,0 +1,109 @@
+import { YemotCall } from "@shared/entities/YemotCall.entity";
+import { Between, DataSource, In } from "typeorm";
+import { YemotRequest, ReportType } from "../../shared/utils/yemot/yemot.interface";
+import { Lesson } from "../db/entities/Lesson.entity";
+import { Klass } from "../db/entities/Klass.entity";
+import { Teacher } from "../db/entities/Teacher.entity";
+import { StudentKlass } from "../db/entities/StudentKlass.entity";
+import { AttReport } from "../db/entities/AttReport.entity";
+import { Grade } from "../db/entities/Grade.entity";
+import { getCurrentHebrewYear } from "../../shared/utils/entity/year.util";
+
+export class YemotRequestImpl extends YemotRequest {
+  constructor(
+    activeCall: YemotCall,
+    dataSource: DataSource,
+  ) {
+    super(activeCall, dataSource);
+  }
+
+  async getLessonFromLessonId(lessonId: number) {
+    return this.dataSource.getRepository(Lesson).findOneBy({
+      userId: this.getUserId(),
+      key: lessonId,
+      year: getCurrentHebrewYear(),
+    });
+  }
+
+  async getKlassByKlassId(klassKey: number, klassId?: number) {
+    if (!!klassId) {
+      return this.dataSource.getRepository(Klass).findOneBy({
+        id: klassId,
+      });
+    }
+    return this.dataSource.getRepository(Klass).findOneBy({
+      userId: this.getUserId(),
+      key: klassKey,
+      year: getCurrentHebrewYear(),
+    });
+  }
+
+  async getTeacherByPhone(phone: string) {
+    return this.dataSource.getRepository(Teacher).findOne({
+      where: [
+        { userId: this.getUserId(), phone },
+        { userId: this.getUserId(), phone2: phone },
+      ]
+    });
+  }
+
+  async getStudentsByKlassId(klassId: number) {
+    const res = await this.dataSource.getRepository(StudentKlass).find({
+      where: {
+        userId: this.getUserId(),
+        klassReferenceId: klassId,
+        year: getCurrentHebrewYear(),
+      },
+      relations: {
+        student: true,
+      },
+      order: {
+        student: {
+          name: 'ASC',
+        }
+      }
+    });
+
+    return res.map(item => item.student).filter(Boolean);
+  }
+
+  async saveReport(reportData: AttReport | Grade, type: ReportType) {
+    const reportEntity = type === 'att' ? AttReport : Grade;
+    const reportRepo = this.dataSource.getRepository(reportEntity);
+
+    const report = reportRepo.create(reportData)
+    await reportRepo.save(report);
+
+    return report;
+  }
+
+  getExistingAttReports(klassId: string, lessonId: string, sheetName: string): Promise<AttReport[]> {
+    return this.dataSource.getRepository(AttReport).findBy({
+      userId: this.getUserId(),
+      sheetName,
+      lessonReferenceId: Number(lessonId),
+      klassReferenceId: Number(klassId),
+      year: getCurrentHebrewYear(),
+    })
+  }
+
+  getExistingGradeReports(klassId: string, lessonId: string, sheetName: string): Promise<Grade[]> {
+    return this.dataSource.getRepository(Grade).findBy({
+      userId: this.getUserId(),
+      lessonReferenceId: Number(lessonId),
+      klassReferenceId: Number(klassId),
+      year: getCurrentHebrewYear(),
+      reportDate: Between(new Date(Date.now() - 2 * 7 * 24 * 60 * 60 * 1000), new Date())
+    })
+  }
+
+  async deleteExistingReports(existingReports: (AttReport | Grade)[], type: ReportType) {
+    if (existingReports.length) {
+      const entity = type === 'att' ? AttReport : Grade;
+      await this.dataSource.getRepository(entity)
+        .delete({
+          id: In(existingReports.map(item => item.id))
+        });
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new implementation of the `YemotRequest` class, integrates it into the `YemotModule`, and updates a submodule reference. The changes primarily focus on extending functionality for handling lessons, classes, teachers, students, and reports in the Yemot system.

### YemotRequest Implementation:
* Added a new `YemotRequestImpl` class in `server/src/yemot/yemot.request.impl.ts`, which extends `YemotRequest` to provide methods for interacting with lessons, classes, teachers, students, and reports. These include fetching entities by ID, saving reports, retrieving existing reports, and deleting reports.

### Integration with YemotModule:
* Updated `YemotModule.register` in `server/src/app.module.ts` to include the new `YemotRequestImpl` implementation as a parameter.
* Added an import statement for `YemotRequestImpl` in `server/src/app.module.ts`.

### Submodule Update:
* Updated the submodule reference in `server/shared` to point to a new commit, likely to incorporate changes required for the new implementation.