### PR TITLE
Merge yemot simulator bump into symlink claude detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docker-compose.override.yml.template
+++ b/docker-compose.override.yml.template
@@ -7,7 +7,6 @@ services:
             target: development
         environment:
             PORT: 3000
-            REACT_APP_API_URL: http://localhost:3001
         ports:
             - "3000:3000"
             - "24678:24678"


### PR DESCRIPTION
This PR targets `symlink-claude-detection` after merging `chore/bump-nra-client-yemot-simulator` into it.

Goal: land both lines of work together into `main`.