### PR TITLE
feat: add gradesLessThan filter to student report card

### DIFF
--- a/client/src/reports/studentReportCardReactButton.jsx
+++ b/client/src/reports/studentReportCardReactButton.jsx
@@ -40,6 +40,11 @@ export default ({ defaultRequestValues }) => {
             <CommonReferenceInput source="klassTypeReferenceId" reference="klass_type" label="שיוך כיתה" />
             <TextInput source="personalNote" label="הערה לתלמידה" defaultValue="" />
             <NumberInput source="attendanceLessThan" label="הצג רק שורות עם נוכחות נמוכה מ (%)" />
+            <NumberInput
+                source="gradesLessThan"
+                label="הצג רק שורות עם ציון נמוך מ (%)"
+                helperText="הסינון מתבצע לפי הציון המקורי, לפני התאמה לפי אחוזי נוכחות"
+            />
         </BulkReportButton>
     );
 };

--- a/client/src/roadmapFeatures.js
+++ b/client/src/roadmapFeatures.js
@@ -18,6 +18,7 @@ export default [
     { html: 'הוספת סינון לפי תאריכים בתעודה', status: 'בוצע', statusColor: 'success' },
     { html: 'מילוי אוטומטי של קבצי מכלול', status: 'בוצע', statusColor: 'success' },
     { html: 'הצגת ציון אחרון במקום ממוצע', status: 'בוצע', statusColor: 'success' },
+    { html: 'הוספת סינון לפי ציון נמוך מ בתעודה', status: 'בוצע', statusColor: 'success' },
 
     // { html: 'הגדרת תקופת זמן לפי תאריכים', status: 'בקרוב', statusColor: 'warning' },
     // { html: 'הגדרת תקופת זמן לפי יום בשבוע', status: 'בוצע', statusColor: 'success' },

--- a/server/src/reports/reportGenerator.ts
+++ b/server/src/reports/reportGenerator.ts
@@ -31,7 +31,8 @@ export function generateStudentReportCard(userId: any, reqExtra: any, generator:
     downComment: getAsBoolean(reqExtra.downComment),
     lastGrade: getAsBoolean(reqExtra.lastGrade),
     debug: getAsBoolean(reqExtra.debug),
-    attendanceLessThan: getAttPercentLessThanParam(reqExtra.attendanceLessThan),
+    attendanceLessThan: getPercentLessThanParam(reqExtra.attendanceLessThan),
+    gradesLessThan: getPercentLessThanParam(reqExtra.gradesLessThan),
   };
   console.log('student report card extra params: ', extraParams);
   const params = getAsArray(reqExtra.ids)?.map((id) => ({
@@ -45,11 +46,11 @@ export function generateStudentReportCard(userId: any, reqExtra: any, generator:
   };
 }
 
-function getAttPercentLessThanParam(attendanceLessThanStr: string): number {
-  if (attendanceLessThanStr) {
-    const attLessThanNum = parseInt(attendanceLessThanStr);
-    if (!isNaN(attLessThanNum)) {
-      return attLessThanNum / 100;
+function getPercentLessThanParam(lessThanStr: string): number {
+  if (lessThanStr) {
+    const lessThanNum = parseInt(lessThanStr);
+    if (!isNaN(lessThanNum)) {
+      return lessThanNum / 100;
     }
   }
   return undefined;

--- a/server/src/reports/studentReportCardReact.tsx
+++ b/server/src/reports/studentReportCardReact.tsx
@@ -498,6 +498,7 @@ export interface IReportParams {
     lastGrade?: boolean;
     debug?: boolean;
     attendanceLessThan?: number;
+    gradesLessThan?: number;
 }
 export const getReportData: IGetReportDataFunction<IReportParams, AppProps> = async (params, dataSource) => {
     const reportDate = getReportDateFilter(dateFromString(params.startDate), dateFromString(params.endDate));
@@ -613,6 +614,9 @@ function getReports(
 function filterReports(reports: IExtenedStudentPercentReport[], reportParams: IReportParams): AppProps['reports'][number]['reports'] {
     return reports.filter(report => {
         if (reportParams.attendanceLessThan && (report.attPercents >= reportParams.attendanceLessThan)) {
+            return false;
+        }
+        if (reportParams.gradesLessThan && (report.gradeAvg >= reportParams.gradesLessThan)) {
             return false;
         }
         return !(


### PR DESCRIPTION
Mirrors the existing attendanceLessThan filter to let a report show only rows with a grade below a given threshold.