### PR TITLE
feat(yemot): add phone-based seminar attendance flow

### DIFF
--- a/client/src/domainTranslations.js
+++ b/client/src/domainTranslations.js
@@ -179,6 +179,7 @@ export default {
             fields: {
                 ...generalResourceFieldsTranslation,
                 tz: 'תז',
+                studentNumber: 'מספר תלמידה',
                 comment: 'הערה',
                 phone: 'טלפון',
                 address: 'כתובת',

--- a/client/src/entities/student.jsx
+++ b/client/src/entities/student.jsx
@@ -62,6 +62,7 @@ const Datagrid = ({ isAdmin, children, ...props }) => {
             {isAdmin && <TextField source="id" />}
             {isAdmin && <ReferenceField source="userId" reference="user" />}
             <TextField source="tz" />
+            <TextField source="studentNumber" />
             <TextField source="name" />
             <TextField source="comment" />
             <TextField source="phone" />
@@ -80,6 +81,7 @@ const Inputs = ({ isCreate, isAdmin }) => {
             {!isCreate && isAdmin && <TextInput source="id" disabled />}
             {isAdmin && <CommonReferenceInput source="userId" reference="user" validate={required()} />}
             <TextInput source="tz" validate={[required(), maxLength(10), unique()]} />
+            <TextInput source="studentNumber" validate={[maxLength(20), unique()]} />
             <TextInput source="name" validate={[required(), maxLength(500)]} />
             <TextInput source="comment" validate={[maxLength(1000)]} />
             <TextInput source="phone" validate={[maxLength(1000)]} />

--- a/client/src/roadmapFeatures.js
+++ b/client/src/roadmapFeatures.js
@@ -19,6 +19,7 @@ export default [
     { html: 'מילוי אוטומטי של קבצי מכלול', status: 'בוצע', statusColor: 'success' },
     { html: 'הצגת ציון אחרון במקום ממוצע', status: 'בוצע', statusColor: 'success' },
     { html: 'הוספת סינון לפי ציון נמוך מ בתעודה', status: 'בוצע', statusColor: 'success' },
+    { html: 'הוספת אפשרות לדיווח נוכחות סמינר בטלפון', status: 'בוצע', statusColor: 'success' },
 
     // { html: 'הגדרת תקופת זמן לפי תאריכים', status: 'בקרוב', statusColor: 'warning' },
     // { html: 'הגדרת תקופת זמן לפי יום בשבוע', status: 'בוצע', statusColor: 'success' },

--- a/client/src/utils/appPermissions.js
+++ b/client/src/utils/appPermissions.js
@@ -14,6 +14,7 @@ export const appPermissions = {
     absenceType: 'absenceType',
     studentView: 'studentView',
     studentAttendanceByKlass: 'studentAttendanceByKlass',
+    seminarAttendanceYemot: 'seminarAttendanceYemot',
 };
 
 export const isScannerUpload = (permissions) => hasPermissionLogic(permissions, appPermissions.scannerUpload);
@@ -61,3 +62,7 @@ export const useIsStudentView = () => useHasPermission(appPermissions.studentVie
 export const isStudentAttendanceByKlass = (permissions) =>
     isAdmin(permissions) || hasPermissionLogic(permissions, appPermissions.studentAttendanceByKlass);
 export const useIsStudentAttendanceByKlass = () => useHasPermission(appPermissions.studentAttendanceByKlass);
+
+export const isSeminarAttendanceYemot = (permissions) =>
+    hasPermissionLogic(permissions, appPermissions.seminarAttendanceYemot);
+export const useIsSeminarAttendanceYemot = () => useHasPermission(appPermissions.seminarAttendanceYemot);

--- a/server/src/db/entities/Student.entity.ts
+++ b/server/src/db/entities/Student.entity.ts
@@ -9,6 +9,7 @@ import { CreatedAtColumn, UpdatedAtColumn } from '@shared/utils/entity/column-ty
 
 @Index('students_users_idx', ['userId'], {})
 @Index(['userId', 'tz', 'year'], { unique: true })
+@Index(['userId', 'studentNumber', 'year'], { unique: true })
 @Entity('students')
 export class Student implements IHasUserId {
   @PrimaryGeneratedColumn({ type: 'int', name: 'id' })
@@ -27,6 +28,13 @@ export class Student implements IHasUserId {
   @IsNotEmpty({ groups: [CrudValidationGroups.CREATE] })
   @Column('varchar', { name: 'tz', length: 10 })
   tz: string;
+
+  @IsOptional({ always: true })
+  @MaxLength(20, { always: true })
+  @StringType
+  @IsUniqueCombination(['userId'], [Student, User], { always: true })
+  @Column('varchar', { name: 'student_number', nullable: true, length: 20 })
+  studentNumber: string;
 
   @IsOptional({ groups: [CrudValidationGroups.UPDATE] })
   @StringType

--- a/server/src/migrations/1783286226248-AddStudentNumberToStudents.ts
+++ b/server/src/migrations/1783286226248-AddStudentNumberToStudents.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddStudentNumberToStudents1783286226248 implements MigrationInterface {
+    name = 'AddStudentNumberToStudents1783286226248'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`students\`
+            ADD \`student_number\` varchar(20) NULL
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`students\`
+            ADD UNIQUE INDEX \`students_user_student_number_year_unique\` (\`user_id\`, \`student_number\`, \`year\`)
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`students\` DROP INDEX \`students_user_student_number_year_unique\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`students\` DROP COLUMN \`student_number\`
+        `);
+    }
+
+}

--- a/server/src/migrations/1783286613243-UpdateYemotTextsSeminarAttendance.ts
+++ b/server/src/migrations/1783286613243-UpdateYemotTextsSeminarAttendance.ts
@@ -2,22 +2,7 @@ import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class UpdateYemotTextsSeminarAttendance1783286613243 implements MigrationInterface {
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query(`DELETE FROM \`texts\` WHERE 1 = 1`);
-
         const texts = [
-            { name: 'GENERAL.YES', text: 'הקישי 1 - כן' },
-            { name: 'GENERAL.NO', text: 'הקישי 2 - לא' },
-            { name: 'GENERAL.INVALID_INPUT', text: 'הקשה לא תקינה, נסי שוב' },
-            { name: 'SYSTEM.CLOSED', text: 'המערכת סגורה. לא ניתן לדווח אחרי השעה תשע וחצי בבוקר. המשך יום טוב.' },
-            { name: 'SYSTEM.REPORT_SUCCESS', text: 'דווח בהצלחה' },
-            { name: 'SYSTEM.LATE_DEPARTURE', text: 'יצאת מאוחר מידי. המשך יום טוב.' },
-            { name: 'STUDENT.TZ_PROMPT', text: 'הקישי מספר תעודת זהות' },
-            { name: 'STUDENT.INVALID_TZ', text: 'מספר תעודת הזהות לא תקין, נסי שוב' },
-            { name: 'STUDENT.ALREADY_REPORTED', text: 'כבר דיווחת היום, לא ניתן לדווח פעמיים.' },
-            { name: 'STUDENT.NO_CLASS', text: 'התלמידה אינה משויכת לכיתה.' },
-            { name: 'TRANSPORT.NUM_PROMPT', text: 'הקישי מספר הסעה' },
-            { name: 'TRANSPORT.INVALID_NUM', text: 'מספר הסעה לא תקין, נסי שוב' },
-            { name: 'TRANSPORT.DEPARTURE_CONFIRM', text: 'האם יצאת לדרך לפני השעה {departureTime}? {yes} {no}' },
             { name: 'TEACHER.PHONE_NOT_RECOGNIZED', text: 'מספר הטלפון שלך אינו מוכר במערכת, אנא פני למזכירות.' },
             { name: 'SEMINAR.KLASS_PROMPT', text: 'הקישי מספר כיתה' },
             { name: 'SEMINAR.INVALID_KLASS', text: 'מספר כיתה לא תקין, נסי שוב' },
@@ -36,5 +21,17 @@ export class UpdateYemotTextsSeminarAttendance1783286613243 implements Migration
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            'DELETE FROM `texts` WHERE `user_id` = 0 AND `name` IN (?, ?, ?, ?, ?, ?, ?)',
+            [
+                'TEACHER.PHONE_NOT_RECOGNIZED',
+                'SEMINAR.KLASS_PROMPT',
+                'SEMINAR.INVALID_KLASS',
+                'SEMINAR.ALREADY_REPORTED',
+                'SEMINAR.ABSENT_STUDENT_PROMPT',
+                'SEMINAR.INVALID_STUDENT_NUM',
+                'SEMINAR.NO_STUDENTS_IN_KLASS',
+            ],
+        );
     }
 }

--- a/server/src/migrations/1783286613243-UpdateYemotTextsSeminarAttendance.ts
+++ b/server/src/migrations/1783286613243-UpdateYemotTextsSeminarAttendance.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateYemotTextsSeminarAttendance1783286613243 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DELETE FROM \`texts\` WHERE 1 = 1`);
+
+        const texts = [
+            { name: 'GENERAL.YES', text: 'הקישי 1 - כן' },
+            { name: 'GENERAL.NO', text: 'הקישי 2 - לא' },
+            { name: 'GENERAL.INVALID_INPUT', text: 'הקשה לא תקינה, נסי שוב' },
+            { name: 'SYSTEM.CLOSED', text: 'המערכת סגורה. לא ניתן לדווח אחרי השעה תשע וחצי בבוקר. המשך יום טוב.' },
+            { name: 'SYSTEM.REPORT_SUCCESS', text: 'דווח בהצלחה' },
+            { name: 'SYSTEM.LATE_DEPARTURE', text: 'יצאת מאוחר מידי. המשך יום טוב.' },
+            { name: 'STUDENT.TZ_PROMPT', text: 'הקישי מספר תעודת זהות' },
+            { name: 'STUDENT.INVALID_TZ', text: 'מספר תעודת הזהות לא תקין, נסי שוב' },
+            { name: 'STUDENT.ALREADY_REPORTED', text: 'כבר דיווחת היום, לא ניתן לדווח פעמיים.' },
+            { name: 'STUDENT.NO_CLASS', text: 'התלמידה אינה משויכת לכיתה.' },
+            { name: 'TRANSPORT.NUM_PROMPT', text: 'הקישי מספר הסעה' },
+            { name: 'TRANSPORT.INVALID_NUM', text: 'מספר הסעה לא תקין, נסי שוב' },
+            { name: 'TRANSPORT.DEPARTURE_CONFIRM', text: 'האם יצאת לדרך לפני השעה {departureTime}? {yes} {no}' },
+            { name: 'TEACHER.PHONE_NOT_RECOGNIZED', text: 'מספר הטלפון שלך אינו מוכר במערכת, אנא פני למזכירות.' },
+            { name: 'SEMINAR.KLASS_PROMPT', text: 'הקישי מספר כיתה' },
+            { name: 'SEMINAR.INVALID_KLASS', text: 'מספר כיתה לא תקין, נסי שוב' },
+            { name: 'SEMINAR.ALREADY_REPORTED', text: 'כבר דיווחת נוכחות לכיתה זו היום, לא ניתן לדווח פעמיים.' },
+            { name: 'SEMINAR.ABSENT_STUDENT_PROMPT', text: 'הקישי מספר תלמידה שנעדרה מהסמינר, ולסיום הקישי 0' },
+            { name: 'SEMINAR.INVALID_STUDENT_NUM', text: 'מספר תלמידה לא תקין, נסי שוב' },
+            { name: 'SEMINAR.NO_STUDENTS_IN_KLASS', text: 'לא נמצאו תלמידות המשויכות לכיתה זו, אנא פני למזכירות.' },
+        ];
+
+        for (const text of texts) {
+            await queryRunner.query(
+                'INSERT INTO `texts` (`user_id`, `name`, `description`, `value`) VALUES (?, ?, ?, ?)',
+                [0, text.name, text.text, text.text],
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+}

--- a/server/src/yemot-handler.service.test.ts
+++ b/server/src/yemot-handler.service.test.ts
@@ -1,4 +1,5 @@
 import { YemotScenarioBuilder, YemotScenarioRunner, useFakeDateOnly } from '@shared/utils/yemot/testing';
+import { getCurrentHebrewYear } from '@shared/utils/entity/year.util';
 import { YemotHandlerService } from './yemot-handler.service';
 
 /**
@@ -232,5 +233,226 @@ describe('YemotHandlerService — react-admin-nestjs', () => {
 
     const result = await runner.run(scenario);
     expect(result.passed).toBe(true);
+  });
+
+  describe('seminar attendance flow', () => {
+    const seminarTexts = [
+      { userId: 0, name: 'TEACHER.PHONE_NOT_RECOGNIZED', description: '', value: 'Teacher phone not recognized' },
+      { userId: 0, name: 'SEMINAR.KLASS_PROMPT', description: '', value: 'Enter klass number' },
+      { userId: 0, name: 'SEMINAR.INVALID_KLASS', description: '', value: 'Invalid klass, try again' },
+      { userId: 0, name: 'SEMINAR.ALREADY_REPORTED', description: '', value: 'Already reported for this klass today' },
+      { userId: 0, name: 'SEMINAR.ABSENT_STUDENT_PROMPT', description: '', value: 'Enter absent student number, or 0 to finish' },
+      { userId: 0, name: 'SEMINAR.INVALID_STUDENT_NUM', description: '', value: 'Invalid student number, try again' },
+      { userId: 0, name: 'SEMINAR.NO_STUDENTS_IN_KLASS', description: '', value: 'No students found for this klass' },
+    ];
+    const allTexts = [...baseTexts, ...seminarTexts];
+
+    const seminarUser = (permissions: Record<string, boolean>) => ({ ...baseUser, permissions });
+    const teacher = { id: 1, userId: 1, tz: '900000001', name: 'Teacher One', phone: '0501234567' };
+    const roster = () => [
+      { id: 101, userId: 1, tz: '300000001', name: 'Student A', studentNumber: '11' },
+      { id: 102, userId: 1, tz: '300000002', name: 'Student B', studentNumber: '12' },
+      { id: 103, userId: 1, tz: '300000003', name: 'Student C', studentNumber: '13' },
+    ];
+    const studentKlasses = (klassReferenceId: number, year: number) => [
+      { id: 501, userId: 1, studentReferenceId: 101, klassReferenceId, year },
+      { id: 502, userId: 1, studentReferenceId: 102, klassReferenceId, year },
+      { id: 503, userId: 1, studentReferenceId: 103, klassReferenceId, year },
+    ];
+
+    it('happy path with lessonSignature permission — creates a ReportGroup/Session and AttReport rows', async () => {
+      jest.setSystemTime(israelTimeAt(7, 0));
+      const year = getCurrentHebrewYear();
+      const klass = { id: 200, userId: 1, key: 7, name: 'Klass Seven', year };
+
+      const scenario = new YemotScenarioBuilder('Seminar happy path with report group')
+        .seed('User', [seminarUser({ seminarAttendanceYemot: true, lessonSignature: true })])
+        .seed('Teacher', [teacher])
+        .seed('Klass', [klass])
+        .seed('Student', roster())
+        .seed('StudentKlass', studentKlasses(200, year))
+        .seed('Text', allTexts)
+        .seed('AttReport', [])
+        .seed('ReportGroup', [])
+        .seed('ReportGroupSession', [])
+        .systemAsks(/enter klass number/i)
+        .userResponds('7')
+        .systemAsks(/enter absent student number/i)
+        .userResponds('11')
+        .systemAsks(/enter absent student number/i)
+        .userResponds('0')
+        .systemHangsUp(/success/i)
+        .build();
+
+      const result = await runner.run(scenario);
+      expect(result.passed).toBe(true);
+      expect(result.hungup).toBe(true);
+
+      expect(result.saved['AttReport']).toHaveLength(3);
+      expect(result.saved['ReportGroup']).toHaveLength(1);
+      expect(result.saved['ReportGroupSession']).toHaveLength(1);
+
+      const session = result.saved['ReportGroupSession'][0];
+      expect(session.startTime).toBeTruthy();
+
+      const byStudent = Object.fromEntries(
+        result.saved['AttReport'].map((r: any) => [r.studentReferenceId, r]),
+      );
+      expect(byStudent[101].absCount).toBe(1);
+      expect(byStudent[102].absCount).toBe(0);
+      expect(byStudent[103].absCount).toBe(0);
+      for (const report of result.saved['AttReport']) {
+        expect(report.reportGroupSessionId).toBe(session.id);
+      }
+    });
+
+    it('happy path without lessonSignature permission — saves AttReport rows without a report group', async () => {
+      jest.setSystemTime(israelTimeAt(7, 0));
+      const year = getCurrentHebrewYear();
+      const klass = { id: 210, userId: 1, key: 8, name: 'Klass Eight', year };
+
+      const scenario = new YemotScenarioBuilder('Seminar happy path without report group')
+        .seed('User', [seminarUser({ seminarAttendanceYemot: true })])
+        .seed('Teacher', [teacher])
+        .seed('Klass', [klass])
+        .seed('Student', roster())
+        .seed('StudentKlass', studentKlasses(210, year))
+        .seed('Text', allTexts)
+        .seed('AttReport', [])
+        .seed('ReportGroup', [])
+        .seed('ReportGroupSession', [])
+        .systemAsks(/enter klass number/i)
+        .userResponds('8')
+        .systemAsks(/enter absent student number/i)
+        .userResponds('11')
+        .systemAsks(/enter absent student number/i)
+        .userResponds('0')
+        .systemHangsUp(/success/i)
+        .build();
+
+      const result = await runner.run(scenario);
+      expect(result.passed).toBe(true);
+      expect(result.hungup).toBe(true);
+
+      expect(result.saved['AttReport']).toHaveLength(3);
+      expect(result.saved['ReportGroup']).toHaveLength(0);
+      expect(result.saved['ReportGroupSession']).toHaveLength(0);
+      for (const report of result.saved['AttReport']) {
+        expect(report.reportGroupSessionId).toBeFalsy();
+      }
+    });
+
+    it('teacher phone not recognized — hangup with TEACHER.PHONE_NOT_RECOGNIZED', async () => {
+      jest.setSystemTime(israelTimeAt(7, 0));
+
+      const scenario = new YemotScenarioBuilder('Seminar unrecognized teacher phone')
+        .seed('User', [seminarUser({ seminarAttendanceYemot: true })])
+        .seed('Text', allTexts)
+        .systemHangsUp(/not recognized/i)
+        .build();
+
+      const result = await runner.run(scenario);
+      expect(result.passed).toBe(true);
+      expect(result.hungup).toBe(true);
+    });
+
+    it('invalid klass number — error message then retry with valid klass', async () => {
+      jest.setSystemTime(israelTimeAt(7, 0));
+      const year = getCurrentHebrewYear();
+      const klass = { id: 220, userId: 1, key: 9, name: 'Klass Nine', year };
+
+      const scenario = new YemotScenarioBuilder('Seminar invalid klass retry')
+        .seed('User', [seminarUser({ seminarAttendanceYemot: true })])
+        .seed('Teacher', [teacher])
+        .seed('Klass', [klass])
+        .seed('Student', roster())
+        .seed('StudentKlass', studentKlasses(220, year))
+        .seed('Text', allTexts)
+        .systemAsks(/enter klass number/i)
+        .userResponds('99')
+        .systemSends(/invalid klass/i)
+        .systemAsks(/enter klass number/i)
+        .userResponds('9')
+        .systemAsks(/enter absent student number/i)
+        .userResponds('0')
+        .systemHangsUp(/success/i)
+        .build();
+
+      const result = await runner.run(scenario);
+      expect(result.passed).toBe(true);
+    });
+
+    it('invalid student number — error message then retry with valid student number', async () => {
+      jest.setSystemTime(israelTimeAt(7, 0));
+      const year = getCurrentHebrewYear();
+      const klass = { id: 230, userId: 1, key: 10, name: 'Klass Ten', year };
+
+      const scenario = new YemotScenarioBuilder('Seminar invalid student number retry')
+        .seed('User', [seminarUser({ seminarAttendanceYemot: true })])
+        .seed('Teacher', [teacher])
+        .seed('Klass', [klass])
+        .seed('Student', roster())
+        .seed('StudentKlass', studentKlasses(230, year))
+        .seed('Text', allTexts)
+        .systemAsks(/enter klass number/i)
+        .userResponds('10')
+        .systemAsks(/enter absent student number/i)
+        .userResponds('999')
+        .systemSends(/invalid student number/i)
+        .systemAsks(/enter absent student number/i)
+        .userResponds('11')
+        .systemAsks(/enter absent student number/i)
+        .userResponds('0')
+        .systemHangsUp(/success/i)
+        .build();
+
+      const result = await runner.run(scenario);
+      expect(result.passed).toBe(true);
+    });
+
+    it('already reported today for this klass — hangup with SEMINAR.ALREADY_REPORTED', async () => {
+      jest.setSystemTime(israelTimeAt(7, 0));
+      const year = getCurrentHebrewYear();
+      const klass = { id: 240, userId: 1, key: 11, name: 'Klass Eleven', year };
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const scenario = new YemotScenarioBuilder('Seminar already reported for klass')
+        .seed('User', [seminarUser({ seminarAttendanceYemot: true })])
+        .seed('Teacher', [teacher])
+        .seed('Klass', [klass])
+        .seed('AttReport', [
+          { id: 900, userId: 1, studentReferenceId: 101, klassReferenceId: 240, reportDate: today, absCount: 0 },
+        ])
+        .seed('Text', allTexts)
+        .systemAsks(/enter klass number/i)
+        .userResponds('11')
+        .systemHangsUp(/already reported/i)
+        .build();
+
+      const result = await runner.run(scenario);
+      expect(result.passed).toBe(true);
+      expect(result.hungup).toBe(true);
+    });
+
+    it('no students in klass — hangup with SEMINAR.NO_STUDENTS_IN_KLASS', async () => {
+      jest.setSystemTime(israelTimeAt(7, 0));
+      const year = getCurrentHebrewYear();
+      const klass = { id: 250, userId: 1, key: 12, name: 'Klass Twelve', year };
+
+      const scenario = new YemotScenarioBuilder('Seminar no students in klass')
+        .seed('User', [seminarUser({ seminarAttendanceYemot: true })])
+        .seed('Teacher', [teacher])
+        .seed('Klass', [klass])
+        .seed('Text', allTexts)
+        .systemAsks(/enter klass number/i)
+        .userResponds('12')
+        .systemHangsUp(/no students/i)
+        .build();
+
+      const result = await runner.run(scenario);
+      expect(result.passed).toBe(true);
+      expect(result.hungup).toBe(true);
+    });
   });
 });

--- a/server/src/yemot-handler.service.ts
+++ b/server/src/yemot-handler.service.ts
@@ -106,17 +106,14 @@ export class YemotHandlerService extends BaseYemotHandlerService {
   }
 
   private async hasReportedTodayForKlass(klassReferenceId: number): Promise<boolean> {
-    const startOfDay = new Date();
-    startOfDay.setHours(0, 0, 0, 0);
-
-    const endOfDay = new Date();
-    endOfDay.setHours(23, 59, 59, 999);
+    const today = new Date();
+    const todayDateOnly = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
 
     const existingReport = await this.dataSource.getRepository(AttReport).findOne({
       where: {
         userId: this.user.id,
         klassReferenceId,
-        reportDate: Between(startOfDay, endOfDay),
+        reportDate: todayDateOnly as unknown as Date,
       },
     });
     return !!existingReport;

--- a/server/src/yemot-handler.service.ts
+++ b/server/src/yemot-handler.service.ts
@@ -1,9 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import { BaseYemotHandlerService } from '@shared/utils/yemot/v2/yemot-router.service';
+import { hasPermission } from '@shared/utils/permissionsUtil';
+import { getCurrentHebrewYear } from '@shared/utils/entity/year.util';
 import { Student } from './db/entities/Student.entity';
 import { Transportation } from './db/entities/Transportation.entity';
 import { KnownAbsence } from './db/entities/KnownAbsence.entity';
 import { StudentKlass } from './db/entities/StudentKlass.entity';
+import { Teacher } from './db/entities/Teacher.entity';
+import { Klass } from './db/entities/Klass.entity';
+import { AttReport } from './db/entities/AttReport.entity';
+import { ReportGroup } from './db/entities/ReportGroup.entity';
+import { ReportGroupSession } from './db/entities/ReportGroupSession.entity';
 import { Between } from 'typeorm';
 /**
  * Yemot Handler Service for processing incoming Yemot calls
@@ -15,6 +22,14 @@ export class YemotHandlerService extends BaseYemotHandlerService {
   override async processCall(): Promise<void> {
     await this.getUserByDidPhone();
     this.logger.log(`Processing call with ID: ${this.call.callId} from phone: ${this.call.phone}`);
+    if (hasPermission(this.user, 'seminarAttendanceYemot')) {
+      await this.processSeminarAttendanceCall();
+    } else {
+      await this.processTransportationCall();
+    }
+  }
+
+  private async processTransportationCall(): Promise<void> {
     if (await this.isPastReportingDeadline()) {
       await this.hangupWithMessageByKey('SYSTEM.CLOSED');
       return;
@@ -36,6 +51,149 @@ export class YemotHandlerService extends BaseYemotHandlerService {
       await this.hangupWithMessageByKey('SYSTEM.LATE_DEPARTURE');
     }
   }
+
+  private async processSeminarAttendanceCall(): Promise<void> {
+    const teacher = await this.getTeacherByPhone();
+    if (!teacher) return;
+
+    const klass = await this.getKlassByInput();
+
+    const alreadyReported = await this.hasReportedTodayForKlass(klass.id);
+    if (alreadyReported) {
+      await this.hangupWithMessageByKey('SEMINAR.ALREADY_REPORTED');
+      return;
+    }
+
+    const roster = await this.getKlassRoster(klass.id);
+    if (roster.length === 0) {
+      await this.hangupWithMessageByKey('SEMINAR.NO_STUDENTS_IN_KLASS');
+      return;
+    }
+
+    const absentStudentReferenceIds = await this.collectAbsentStudentIds();
+    await this.saveSeminarAttendance(teacher, klass, roster, absentStudentReferenceIds);
+    await this.hangupWithMessageByKey('SYSTEM.REPORT_SUCCESS');
+  }
+
+  private async getTeacherByPhone(): Promise<Teacher | null> {
+    const teacher = await this.dataSource.getRepository(Teacher).findOne({
+      where: [
+        { userId: this.user.id, phone: this.call.phone },
+        { userId: this.user.id, phone2: this.call.phone },
+      ],
+    });
+    if (!teacher) {
+      await this.hangupWithMessageByKey('TEACHER.PHONE_NOT_RECOGNIZED');
+      return null;
+    }
+    return teacher;
+  }
+
+  private async getKlassByInput(): Promise<Klass> {
+    let klass: Klass = null;
+    while (!klass) {
+      const key = await this.askForInputByKey('SEMINAR.KLASS_PROMPT');
+      klass = await this.dataSource.getRepository(Klass).findOneBy({
+        userId: this.user.id,
+        key: Number(key),
+        year: getCurrentHebrewYear(),
+      });
+      if (!klass) {
+        await this.sendMessageByKey('SEMINAR.INVALID_KLASS');
+      }
+    }
+    return klass;
+  }
+
+  private async hasReportedTodayForKlass(klassReferenceId: number): Promise<boolean> {
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+
+    const endOfDay = new Date();
+    endOfDay.setHours(23, 59, 59, 999);
+
+    const existingReport = await this.dataSource.getRepository(AttReport).findOne({
+      where: {
+        userId: this.user.id,
+        klassReferenceId,
+        reportDate: Between(startOfDay, endOfDay),
+      },
+    });
+    return !!existingReport;
+  }
+
+  private async getKlassRoster(klassReferenceId: number): Promise<StudentKlass[]> {
+    return this.dataSource.getRepository(StudentKlass).find({
+      where: {
+        userId: this.user.id,
+        klassReferenceId,
+        year: getCurrentHebrewYear(),
+      },
+    });
+  }
+
+  private async collectAbsentStudentIds(): Promise<Set<number>> {
+    const absentStudentReferenceIds = new Set<number>();
+    let input = await this.askForInputByKey('SEMINAR.ABSENT_STUDENT_PROMPT');
+    while (input !== '0') {
+      const student = await this.dataSource.getRepository(Student).findOneBy({
+        userId: this.user.id,
+        studentNumber: input,
+      });
+      if (!student) {
+        await this.sendMessageByKey('SEMINAR.INVALID_STUDENT_NUM');
+      } else {
+        absentStudentReferenceIds.add(student.id);
+      }
+      input = await this.askForInputByKey('SEMINAR.ABSENT_STUDENT_PROMPT');
+    }
+    return absentStudentReferenceIds;
+  }
+
+  private async saveSeminarAttendance(
+    teacher: Teacher,
+    klass: Klass,
+    roster: StudentKlass[],
+    absentStudentReferenceIds: Set<number>,
+  ): Promise<void> {
+    const reportDate = new Date();
+    let reportGroupSessionId: number | undefined;
+
+    if (hasPermission(this.user, 'lessonSignature')) {
+      const reportGroup = await this.dataSource.getRepository(ReportGroup).save({
+        userId: this.user.id,
+        name: `נוכחות סמינר - ${klass.name}`,
+        topic: 'נוכחות סמינר',
+        teacherReferenceId: teacher.id,
+        klassReferenceId: klass.id,
+        year: getCurrentHebrewYear(),
+      });
+
+      const reportGroupSession = await this.dataSource.getRepository(ReportGroupSession).save({
+        userId: this.user.id,
+        reportGroupId: reportGroup.id,
+        sessionDate: reportDate,
+        startTime: reportDate.toLocaleTimeString('en-GB', { timeZone: 'Asia/Jerusalem', hour12: false }),
+      });
+
+      reportGroupSessionId = reportGroupSession.id;
+    }
+
+    const attReportRepo = this.dataSource.getRepository(AttReport);
+    const rows = roster.map((studentKlass) =>
+      attReportRepo.create({
+        userId: this.user.id,
+        studentReferenceId: studentKlass.studentReferenceId,
+        teacherReferenceId: teacher.id,
+        klassReferenceId: klass.id,
+        reportGroupSessionId,
+        reportDate,
+        absCount: absentStudentReferenceIds.has(studentKlass.studentReferenceId) ? 1 : 0,
+      }),
+    );
+    await attReportRepo.save(rows);
+  }
+
   private isPastReportingDeadline(): boolean {
     const now = new Date();
     const israelTime = new Date(now.toLocaleString('en-US', { timeZone: 'Asia/Jerusalem' }));

--- a/server/src/yemot-handler.service.ts
+++ b/server/src/yemot-handler.service.ts
@@ -105,9 +105,12 @@ export class YemotHandlerService extends BaseYemotHandlerService {
     return klass;
   }
 
+  private getIsraelDateString(date: Date): string {
+    return date.toLocaleDateString('en-CA', { timeZone: 'Asia/Jerusalem' });
+  }
+
   private async hasReportedTodayForKlass(klassReferenceId: number): Promise<boolean> {
-    const today = new Date();
-    const todayDateOnly = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+    const todayDateOnly = this.getIsraelDateString(new Date());
 
     const existingReport = await this.dataSource.getRepository(AttReport).findOne({
       where: {
@@ -153,42 +156,47 @@ export class YemotHandlerService extends BaseYemotHandlerService {
     roster: StudentKlass[],
     absentStudentReferenceIds: Set<number>,
   ): Promise<void> {
-    const reportDate = new Date();
-    let reportGroupSessionId: number | undefined;
+    const now = new Date();
+    const reportDate = this.getIsraelDateString(now) as unknown as Date;
+    const callTime = now.toLocaleTimeString('en-GB', { timeZone: 'Asia/Jerusalem', hour12: false });
 
-    if (hasPermission(this.user, 'lessonSignature')) {
-      const reportGroup = await this.dataSource.getRepository(ReportGroup).save({
-        userId: this.user.id,
-        name: `נוכחות סמינר - ${klass.name}`,
-        topic: 'נוכחות סמינר',
-        teacherReferenceId: teacher.id,
-        klassReferenceId: klass.id,
-        year: getCurrentHebrewYear(),
-      });
+    await this.dataSource.transaction(async (manager) => {
+      let reportGroupSessionId: number | undefined;
 
-      const reportGroupSession = await this.dataSource.getRepository(ReportGroupSession).save({
-        userId: this.user.id,
-        reportGroupId: reportGroup.id,
-        sessionDate: reportDate,
-        startTime: reportDate.toLocaleTimeString('en-GB', { timeZone: 'Asia/Jerusalem', hour12: false }),
-      });
+      if (hasPermission(this.user, 'lessonSignature')) {
+        const reportGroup = await manager.getRepository(ReportGroup).save({
+          userId: this.user.id,
+          name: `נוכחות סמינר - ${klass.name}`,
+          topic: 'נוכחות סמינר',
+          teacherReferenceId: teacher.id,
+          klassReferenceId: klass.id,
+          year: getCurrentHebrewYear(),
+        });
 
-      reportGroupSessionId = reportGroupSession.id;
-    }
+        const reportGroupSession = await manager.getRepository(ReportGroupSession).save({
+          userId: this.user.id,
+          reportGroupId: reportGroup.id,
+          sessionDate: reportDate,
+          startTime: callTime,
+        });
 
-    const attReportRepo = this.dataSource.getRepository(AttReport);
-    const rows = roster.map((studentKlass) =>
-      attReportRepo.create({
-        userId: this.user.id,
-        studentReferenceId: studentKlass.studentReferenceId,
-        teacherReferenceId: teacher.id,
-        klassReferenceId: klass.id,
-        reportGroupSessionId,
-        reportDate,
-        absCount: absentStudentReferenceIds.has(studentKlass.studentReferenceId) ? 1 : 0,
-      }),
-    );
-    await attReportRepo.save(rows);
+        reportGroupSessionId = reportGroupSession.id;
+      }
+
+      const attReportRepo = manager.getRepository(AttReport);
+      const rows = roster.map((studentKlass) =>
+        attReportRepo.create({
+          userId: this.user.id,
+          studentReferenceId: studentKlass.studentReferenceId,
+          teacherReferenceId: teacher.id,
+          klassReferenceId: klass.id,
+          reportGroupSessionId,
+          reportDate,
+          absCount: absentStudentReferenceIds.has(studentKlass.studentReferenceId) ? 1 : 0,
+        }),
+      );
+      await attReportRepo.save(rows);
+    });
   }
 
   private isPastReportingDeadline(): boolean {


### PR DESCRIPTION
Schools with permissions.seminarAttendanceYemot route to a new flow where a teacher (matched by caller ID) keys a class number then the numbers of absent students; everyone else in the class is recorded present. Adds Student.studentNumber as a keypad-friendly student identifier, and links AttReport rows to a ReportGroup/ReportGroupSession (same mechanism as the web in-lesson-report form) when the school has lessonSignature permission, storing the call's time there.