### PR TITLE
Allow OR between attendance/grade limit filters in student report card

### DIFF
--- a/client/src/entities/lesson-schedule.jsx
+++ b/client/src/entities/lesson-schedule.jsx
@@ -112,7 +112,6 @@ const entity = {
     Representation,
     filters,
     filterDefaultValues,
-    importer: false,
     additionalListActions,
 };
 

--- a/client/src/entities/lesson-schedule.jsx
+++ b/client/src/entities/lesson-schedule.jsx
@@ -112,6 +112,7 @@ const entity = {
     Representation,
     filters,
     filterDefaultValues,
+    importer: false,
     additionalListActions,
 };
 

--- a/client/src/reports/studentReportCardReactButton.jsx
+++ b/client/src/reports/studentReportCardReactButton.jsx
@@ -1,4 +1,4 @@
-import { TextInput, DateInput, NumberInput } from 'react-admin';
+import { TextInput, DateInput, NumberInput, BooleanInput } from 'react-admin';
 import { defaultYearFilter } from '@shared/utils/yearFilter';
 import { CommonYearInput } from '@shared/components/fields/CommonYear';
 import NoteAltIcon from '@mui/icons-material/NoteAlt';
@@ -44,6 +44,10 @@ export default ({ defaultRequestValues }) => {
                 source="gradesLessThan"
                 label="הצג רק שורות עם ציון נמוך מ (%)"
                 helperText="הסינון מתבצע לפי הציון המקורי, לפני התאמה לפי אחוזי נוכחות"
+            />
+            <BooleanInput
+                source="limitFilterUseOr"
+                label="כאשר שני הסינונים הקודמים מלאים, הצג שורה כשמתקיים לפחות אחד מהם (במקום שניהם יחד)"
             />
         </BulkReportButton>
     );

--- a/client/src/roadmapFeatures.js
+++ b/client/src/roadmapFeatures.js
@@ -22,6 +22,7 @@ export default [
     { html: 'הוספת אפשרות לדיווח נוכחות סמינר בטלפון', status: 'בוצע', statusColor: 'success' },
     { html: 'הוספת אפשרות לעדכון מספר טלפון בהגדרות', status: 'בוצע', statusColor: 'success' },
     { html: 'העלאת קובץ אקסל של מערכת שעות וזיהוי אוטומטי של השיעור בדיווח נוכחות בטלפון', status: 'בוצע', statusColor: 'success' },
+    { html: 'אפשרות לבחור בין "וגם" ל"או" בין סינון נוכחות וציון בתעודה', status: 'בוצע', statusColor: 'success' },
 
     // { html: 'הגדרת תקופת זמן לפי תאריכים', status: 'בקרוב', statusColor: 'warning' },
     // { html: 'הגדרת תקופת זמן לפי יום בשבוע', status: 'בוצע', statusColor: 'success' },

--- a/server/src/reports/reportGenerator.ts
+++ b/server/src/reports/reportGenerator.ts
@@ -33,6 +33,7 @@ export function generateStudentReportCard(userId: any, reqExtra: any, generator:
     debug: getAsBoolean(reqExtra.debug),
     attendanceLessThan: getPercentLessThanParam(reqExtra.attendanceLessThan),
     gradesLessThan: getPercentLessThanParam(reqExtra.gradesLessThan),
+    limitFilterUseOr: getAsBoolean(reqExtra.limitFilterUseOr),
   };
   console.log('student report card extra params: ', extraParams);
   const params = getAsArray(reqExtra.ids)?.map((id) => ({

--- a/server/src/reports/studentReportCardReact.tsx
+++ b/server/src/reports/studentReportCardReact.tsx
@@ -499,6 +499,7 @@ export interface IReportParams {
     debug?: boolean;
     attendanceLessThan?: number;
     gradesLessThan?: number;
+    limitFilterUseOr?: boolean;
 }
 export const getReportData: IGetReportDataFunction<IReportParams, AppProps> = async (params, dataSource) => {
     const reportDate = getReportDateFilter(dateFromString(params.startDate), dateFromString(params.endDate));
@@ -613,12 +614,20 @@ function getReports(
 
 function filterReports(reports: IExtenedStudentPercentReport[], reportParams: IReportParams): AppProps['reports'][number]['reports'] {
     return reports.filter(report => {
-        if (reportParams.attendanceLessThan && (report.attPercents >= reportParams.attendanceLessThan)) {
+        const failsAttendanceLimit = reportParams.attendanceLessThan && report.attPercents >= reportParams.attendanceLessThan;
+        const failsGradesLimit = reportParams.gradesLessThan && report.gradeAvg >= reportParams.gradesLessThan;
+
+        if (reportParams.attendanceLessThan && reportParams.gradesLessThan) {
+            const passesLimits = reportParams.limitFilterUseOr
+                ? !failsAttendanceLimit || !failsGradesLimit
+                : !failsAttendanceLimit && !failsGradesLimit;
+            if (!passesLimits) {
+                return false;
+            }
+        } else if (failsAttendanceLimit || failsGradesLimit) {
             return false;
         }
-        if (reportParams.gradesLessThan && (report.gradeAvg >= reportParams.gradesLessThan)) {
-            return false;
-        }
+
         return !(
             (reportParams.forceGrades && (report.gradeAvg === undefined || report.gradeAvg === null)) ||
             (reportParams.forceAtt && !report.lessonsCount)


### PR DESCRIPTION
## Summary
- Previously, when both `attendanceLessThan` and `gradesLessThan` were set on the student report card ("תעודה לתלמידה"), a row had to satisfy both to be shown (AND).
- Added a `limitFilterUseOr` toggle so a row can be shown when it satisfies either limit instead, defaulting to the existing AND behavior so no existing reports change.
- Added a `BooleanInput` checkbox in the report button UI to let users choose per-report, and a roadmap entry per this repo's convention.

## Test plan
- [x] Verified the new filter logic (AND default, OR opt-in, single-filter, no-filter cases) against a standalone simulation of `filterReports`.
- [ ] Manual smoke test of the "תעודה לתלמידה" report with both limits filled, toggling the new checkbox.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VoMC9zT3QdXEaX2iB4bgTe)_