### PR TITLE
fix: use shared CommonPhoneResources instead of nonexistent 'phone' menu group

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -8,6 +8,7 @@ import AdminAppShell from '@shared/components/app/AdminAppShell';
 import CommonRoutes from '@shared/components/app/CommonRoutes';
 import CommonAdminResources from '@shared/components/app/CommonAdminResources';
 import CommonSettingsResources from '@shared/components/app/CommonSettingsResources';
+import CommonPhoneResources from '@shared/components/app/CommonPhoneResources';
 import { CommonRepresentation } from '@shared/components/CommonRepresentation';
 
 import { Layout } from 'src/GeneralLayout';
@@ -33,8 +34,6 @@ import teacher from 'src/entities/teacher';
 import transportation from 'src/entities/transportation';
 import absenceType from 'src/entities/absenceType';
 import uploadedFile from '@shared/components/common-entities/uploaded-file';
-import phoneCampaign from '@shared/components/common-entities/phone-campaign';
-import phoneTemplate from '@shared/components/common-entities/phone-template';
 import studentKlassesReport from 'src/entities/student-klasses-report';
 import StudentEventReport from 'src/components/StudentView/student-event-report';
 import reportMonth from 'src/entities/report-month';
@@ -53,7 +52,7 @@ import StudentAttendanceList from 'src/pivots/StudentAttendanceList';
 import StudentAttendanceByKlassList from 'src/pivots/StudentAttendanceByKlassList';
 import PercentReportWithDatesList from 'src/pivots/PercentReportWithDatesList';
 
-import { isUploadedFiles, isAdmin, isPhoneCampaign } from '@shared/utils/permissionsUtil';
+import { isUploadedFiles, isAdmin } from '@shared/utils/permissionsUtil';
 import {
     isLessonSignature,
     isOnlyInLessonReport,
@@ -86,7 +85,6 @@ import DateRangeIcon from '@mui/icons-material/DateRange';
 import LabelIcon from '@mui/icons-material/Label';
 import CalculateIcon from '@mui/icons-material/Calculate';
 import UploadFileIcon from '@mui/icons-material/UploadFile';
-import PhoneIcon from '@mui/icons-material/Phone';
 import PermContactCalendarIcon from '@mui/icons-material/PermContactCalendar';
 import LocalAtmIcon from '@mui/icons-material/LocalAtm';
 import AdminPanelSettingsIcon from '@mui/icons-material/AdminPanelSettings';
@@ -256,22 +254,7 @@ const App = () => (
                             icon={UploadFileIcon}
                         />
                     )}
-                    {isPhoneCampaign(permissions) && (
-                        <>
-                            <Resource
-                                name="phone_template"
-                                {...phoneTemplate}
-                                options={{ menuGroup: 'phone' }}
-                                icon={PhoneIcon}
-                            />
-                            <Resource
-                                name="phone_campaign"
-                                {...phoneCampaign}
-                                options={{ menuGroup: 'phone' }}
-                                icon={PhoneIcon}
-                            />
-                        </>
-                    )}
+                    {CommonPhoneResources({ permissions })}
                     <Resource
                         name="att_report"
                         {...attReport}


### PR DESCRIPTION
## Summary
- `phone_template`/`phone_campaign` were hand-rolled with `menuGroup: 'phone'`, but no `'phone'` group is defined in `GeneralLayout`'s `menuGroups`, so they rendered as ungrouped top-level items instead of inside a submenu.
- Switched to the shared `CommonPhoneResources` component (`client/shared/components/app/CommonPhoneResources.jsx`), already used correctly by dnd-management-nra, which places them under the existing `settings` group.
- Removed now-unused imports (`phoneCampaign`, `phoneTemplate`, `PhoneIcon`, `isPhoneCampaign`).

## Test plan
- `grep -n "menuGroup: 'phone'" client/src/App.jsx` returns nothing.
- Manual review confirms no orphaned imports remain.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HsvtBQrEGncYMKemdv5WjP)_