### PR TITLE
Add public homepage at "/" for SEO, login moves to "/login"

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,15 +7,18 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="נוכחות - מערכת דיגיטלית לניהול נוכחות מורות ותלמידות, דוחות וציונים לבתי ספר וסמינרים"
     />
+    <meta property="og:title" content="נוכחות - מערכת ניהול נוכחות לבתי ספר" />
+    <meta property="og:description" content="מערכת דיגיטלית לניהול נוכחות מורות ותלמידות, דוחות וציונים - לבתי ספר וסמינרים" />
+    <meta property="og:type" content="website" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
     <link rel="manifest" href="/manifest.json" />
-    <title>נוכחות</title>
+    <title>נוכחות - מערכת ניהול נוכחות לבתי ספר</title>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
       new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -95,6 +95,29 @@ import CelebrationIcon from '@mui/icons-material/Celebration';
 
 const themeOptions = { primary: blue[700], secondary: purple[500] };
 
+const homeContent = {
+    appTitle: 'נוכחות',
+    tagline: 'מערכת דיגיטלית לניהול נוכחות מורות ותלמידות, דוחות וציונים - לבתי ספר וסמינרים',
+    description:
+        'נוכחות היא מערכת ניהול מקיפה לבתי ספר וסמינרים, המרכזת את דיווח הנוכחות של מורות ותלמידות, ' +
+        'ניהול ציונים, כיתות ומערכת שעות - במקום אחד, עם דוחות ברורים לצוות ולהנהלה.',
+    features: [
+        {
+            title: 'דיווח נוכחות פשוט',
+            text: 'דיווח נוכחות למורות ולתלמידות דרך האתר או בטלפון, עם זיהוי אוטומטי של השיעור.',
+        },
+        {
+            title: 'דוחות וייצוא נתונים',
+            text: 'דוחות נוכחות, ציונים וחיסורים מאושרים, עם אפשרות סינון וייצוא לאקסל.',
+        },
+        {
+            title: 'ניהול כיתות וציונים',
+            text: 'ניהול כיתות, שיוך תלמידות, מערכת שעות וטופס ציונים - הכל במערכת אחת.',
+        },
+    ],
+    ctaLabel: 'כניסה למערכת',
+};
+
 const App = () => (
     <AdminAppShell
         title="נוכחות"
@@ -102,6 +125,7 @@ const App = () => (
         domainTranslations={domainTranslations}
         dashboard={RootDashboard}
         layout={Layout}
+        homeContent={homeContent}
     >
         {(permissions) => {
             const onlyInLesson = isOnlyInLessonReport(permissions) && !isAdmin(permissions);

--- a/client/src/roadmapFeatures.js
+++ b/client/src/roadmapFeatures.js
@@ -23,6 +23,7 @@ export default [
     { html: 'הוספת אפשרות לעדכון מספר טלפון בהגדרות', status: 'בוצע', statusColor: 'success' },
     { html: 'העלאת קובץ אקסל של מערכת שעות וזיהוי אוטומטי של השיעור בדיווח נוכחות בטלפון', status: 'בוצע', statusColor: 'success' },
     { html: 'אפשרות לבחור בין "וגם" ל"או" בין סינון נוכחות וציון בתעודה', status: 'בוצע', statusColor: 'success' },
+    { html: 'הוספת דף בית פומבי המסביר את המערכת', status: 'בוצע', statusColor: 'success' },
 
     // { html: 'הגדרת תקופת זמן לפי תאריכים', status: 'בקרוב', statusColor: 'warning' },
     // { html: 'הגדרת תקופת זמן לפי יום בשבוע', status: 'בוצע', statusColor: 'success' },


### PR DESCRIPTION
## Summary
- Bumps `client/shared` to pick up `AdminAppShell`'s new `homeContent` prop ([nra-client#24](https://github.com/buzz-code/nra-client/pull/24)): anonymous visitors hitting `/` now see a marketing/explainer page for "נוכחות" (what the attendance system does, for schools evaluating it) instead of being redirected to the login form. Login is unaffected at `/login`.
- Passes Hebrew marketing copy (tagline + 3 feature cards) into `AdminAppShell` via `App.jsx`.
- Updates `client/index.html`'s `<title>`/`<meta description>`/OG tags with real descriptive copy, replacing the CRA placeholder.
- Adds a roadmap entry per this project's `roadmapFeatures.js` convention.

## Test plan
- [x] `yarn test` (client) — 22 suites / 152 tests passing
- [x] End-to-end manual verification against a mock backend + headless browser: `/` shows the homepage anonymously (renders fast, no spinner delay), `/login` still shows the unchanged login form, and logging in lands on the real dashboard at `/` exactly as before
- [x] No route or behavior changes for authenticated users (dashboard, resource routes, existing bookmarks all unaffected)


---
_Generated by [Claude Code](https://claude.ai/code/session_01K6vscyBHEDv9MxcyJLVjjh)_