### PR TITLE
Fix client 502/503 on deploy: start_period 60s + lb retries

### DIFF
--- a/docker-compose-swarm.yml
+++ b/docker-compose-swarm.yml
@@ -13,6 +13,8 @@ services:
                 caddy.reverse_proxy.health_uri: '/'
                 caddy.reverse_proxy.health_interval: 5s
                 caddy.reverse_proxy.health_timeout: 5s
+                caddy.reverse_proxy.lb_try_duration: 5s
+                caddy.reverse_proxy.lb_retries: 3
             placement:
                 constraints:
                     - node.labels.codeserver != true
@@ -33,7 +35,7 @@ services:
             test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:80/"]
             interval: 30s
             timeout: 10s
-            start_period: 30s
+            start_period: 60s
             retries: 3
         environment:
             PORT: 80


### PR DESCRIPTION
## Summary
Same fix verified working on `dnd-management-nra` (#65, #66), applied here:
- `client`'s healthcheck `start_period` bumped from 30s to 60s to match `server` — gives Caddy's independent active health check enough time to confirm the new container healthy before Swarm's `start-first` rolling update retires the old one.
- `caddy.reverse_proxy.lb_try_duration: 5s` / `lb_retries: 3` added to `client`'s labels — a request landing on the old container while it drains after `SIGQUIT` (still "running" per Docker, but refusing new connections) now transparently retries against the healthy upstream instead of surfacing 502/503 to the browser.

## Test plan
- [ ] Deploy and watch for 502/503 during a rolling update of `client`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FGbeRGY9XRt4XnwzgegUFF)_