### PR TITLE
Add Hebrew translation for comment field in domain translations

### DIFF
--- a/client/src/domainTranslations.js
+++ b/client/src/domainTranslations.js
@@ -210,6 +210,7 @@ export default {
                 phone2: 'טלפון 2',
                 email: 'כתובת מייל',
                 displayName: 'שם לתעודה',
+                comment: 'הערה',
             },
         },
         transportation: {


### PR DESCRIPTION
## Summary
Added Hebrew translation for the `comment` field in the domain translations file to support the client entity's comment field display.

## Changes
- Added `comment: 'הערה'` (Hebrew for "comment") to the Hebrew translations object in `client/src/domainTranslations.js`

## Details
This translation entry enables proper localization of the comment field when displayed in the React-Admin UI for Hebrew-speaking users. The translation follows the existing pattern in the file and is placed alongside other field translations in the same section.

https://claude.ai/code/session_01R4k2pAz55HSq5WzM2cHede