### PR TITLE
Update client/shared to nra-client's latest main

### DIFF
--- a/client/src/settings/Settings.jsx
+++ b/client/src/settings/Settings.jsx
@@ -67,7 +67,7 @@ export default function Settings() {
                 <ResourceContextProvider value="settings">
                     <SimpleForm onSubmit={handleSave} defaultValues={defaultValues} toolbar={<SettingsToolbar />}>
                         <GeneralSettingsInput />
-                        <PhoneSettingsInput />
+                        <PhoneSettingsInput subtitle="מספר הטלפון שלך, לזיהוי שיחות נכנסות למערכת" />
                         <ReportStylesInput />
                         <ReportCardSettingsInput />
                         <CommonSettingsAccordion

--- a/client/src/settings/Settings.jsx
+++ b/client/src/settings/Settings.jsx
@@ -67,7 +67,7 @@ export default function Settings() {
                 <ResourceContextProvider value="settings">
                     <SimpleForm onSubmit={handleSave} defaultValues={defaultValues} toolbar={<SettingsToolbar />}>
                         <GeneralSettingsInput />
-                        <PhoneSettingsInput subtitle="מספר הטלפון שלך, לזיהוי שיחות נכנסות למערכת" />
+                        <PhoneSettingsInput />
                         <ReportStylesInput />
                         <ReportCardSettingsInput />
                         <CommonSettingsAccordion


### PR DESCRIPTION
## Summary
- Bump `client/shared` submodule to nra-client's latest `main` (buzz-code/nra-client#33), which corrects `PhoneSettingsInput`'s default subtitle to describe the number as the account's registered Yemot number instead of the previous "for sending messages" text.

## Test plan
- [x] `yarn test` in client passes (27 suites, 177 tests)
- [x] `yarn build` in client passes
- [x] `yarn build` in server passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01JWhMYTU8nWdtFgRpCWmWJe)_