### PR TITLE
Group phone settings into one accordion

### DIFF
--- a/client/src/settings/Settings.jsx
+++ b/client/src/settings/Settings.jsx
@@ -67,17 +67,23 @@ export default function Settings() {
                 <ResourceContextProvider value="settings">
                     <SimpleForm onSubmit={handleSave} defaultValues={defaultValues} toolbar={<SettingsToolbar />}>
                         <GeneralSettingsInput />
-                        <PhoneSettingsInput />
                         <ReportStylesInput />
                         <ReportCardSettingsInput />
                         <CommonSettingsAccordion
-                            id="advanced-settings"
-                            title="הגדרות מתקדמות"
-                            subtitle="ניהול כרטיסי תמונת מצב וחיבור Yemot"
+                            id="phone-settings-group"
+                            title="הגדרות טלפון"
+                            subtitle="מספר טלפון, חיבור Yemot וטלפון מנהלת"
                         >
-                            <DashboardItemsInput />
+                            <PhoneSettingsInput />
                             <YemotSettingsInput />
                             <ManagerPhoneSettingsInput />
+                        </CommonSettingsAccordion>
+                        <CommonSettingsAccordion
+                            id="advanced-settings"
+                            title="הגדרות מתקדמות"
+                            subtitle="ניהול כרטיסי תמונת מצב"
+                        >
+                            <DashboardItemsInput />
                         </CommonSettingsAccordion>
                     </SimpleForm>
                 </ResourceContextProvider>


### PR DESCRIPTION
## Summary
- Move phoneNumber, YemotSettingsInput, ManagerPhoneSettingsInput under one "הגדרות טלפון" accordion instead of scattered placement. Each keeps its own inner accordion.

## Test plan
- [x] yarn build (client)
- [x] yarn test (client) — 27 suites, 177 tests


---
_Generated by [Claude Code](https://claude.ai/code/session_01JWhMYTU8nWdtFgRpCWmWJe)_