### PR TITLE
Exclude signatureData when report_group_session joins reportGroup

### DIFF
--- a/server/src/entity-modules/__tests__/report-group-session.config.spec.ts
+++ b/server/src/entity-modules/__tests__/report-group-session.config.spec.ts
@@ -5,7 +5,7 @@ import config from '../report-group-session.config';
 createEntityConfigTests('ReportGroupSessionConfig', config, {
   entity: ReportGroupSession,
   expectedJoins: {
-    reportGroup: { eager: false },
+    reportGroup: { eager: false, exclude: ['signatureData'] },
     attReports: { eager: false },
     grades: { eager: false },
   },

--- a/server/src/entity-modules/report-group-session.config.ts
+++ b/server/src/entity-modules/report-group-session.config.ts
@@ -97,7 +97,7 @@ function getConfig(): BaseEntityModuleOptions {
     service: ReportGroupSessionService,
     query: {
       join: {
-        reportGroup: { eager: false },
+        reportGroup: { eager: false, exclude: ['signatureData'] },
         attReports: { eager: false },
         grades: { eager: false },
       },


### PR DESCRIPTION
## Summary
- `report_group_session` list requests (`join[]=reportGroup`, the normal session filter/sort view) were still pulling the full base64 `signatureData` image for every row - excluding it from `report_group`'s own CRUD config doesn't cover it being pulled in as a joined relation from a sibling entity's endpoint.
- Fixed with `@dataui/crud`'s per-join `exclude` option (`server/src/entity-modules/report-group-session.config.ts`), same mechanism as the earlier `report_group` fix, just declared at the join site.
- Checked for other exposure: no other CRUD config joins `reportGroup`. The only other reads of `reportGroup.signatureData` are direct repository queries in two report generators, which bypass the CRUD builder and correctly still get the real signature.

## Test plan
- [x] `yarn test` - 912/912 passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01FbmVe5RoQivC1e53KKEr97)_