### PR TITLE
Add studentNumber field to student import

### DIFF
--- a/client/src/entities/student.jsx
+++ b/client/src/entities/student.jsx
@@ -112,7 +112,7 @@ const Inputs = ({ isCreate, isAdmin }) => {
 const Representation = CommonRepresentation;
 
 const importer = {
-    fields: ['tz', 'name', 'comment', 'phone', 'address', 'isActive'],
+    fields: ['tz', 'studentNumber', 'name', 'comment', 'phone', 'address', 'isActive'],
 };
 
 const entity = {


### PR DESCRIPTION
Add `studentNumber` to student entity importer fields list.

**Changes:**
- Added `studentNumber` to importer fields array in student entity config

**Details:**
Student import now includes `studentNumber` field alongside existing fields (tz, name, comment, phone, address, isActive). Enables bulk import of student records with student number data.

https://claude.ai/code/session_01Et47TXkEibump9Jhx4YTeR