### PR TITLE
Add per-date lesson count override for in-lesson reports

### DIFF
--- a/client/src/reports/in-lesson-report/StudentList.jsx
+++ b/client/src/reports/in-lesson-report/StudentList.jsx
@@ -24,7 +24,7 @@ import DeleteIcon from '@mui/icons-material/Delete';
 import { CommonSliderInput } from '../../../shared/components/fields/CommonSliderInput';
 import { ReportContext } from './context';
 import { CommonHebrewDateField } from '@shared/components/fields/CommonHebrewDateField';
-import { useIsLessonSignature } from 'src/utils/appPermissions';
+import { useIsLessonSignature, useIsPerDateLessonCount } from 'src/utils/appPermissions';
 
 export const getDefaultReportDate = () => new Date().toISOString().split('T')[0];
 
@@ -32,6 +32,7 @@ export const StudentList = ({ reportDates, setReportDates }) => {
     const { gradeMode, isShowLate, students } = useContext(ReportContext);
     const record = useRecordContext();
     const hasLessonSignaturePermission = useIsLessonSignature();
+    const hasPerDateLessonCountPermission = useIsPerDateLessonCount();
     const today = useMemo(() => new Date().toISOString().split('T')[0], []);
 
     const columns = useMemo(() => {
@@ -75,11 +76,11 @@ export const StudentList = ({ reportDates, setReportDates }) => {
     );
 
     return (
-        <TableContainer component={Paper}>
+        <TableContainer component={Paper} sx={{ maxHeight: '70vh' }}>
             <Table stickyHeader size="small">
                 <TableHead>
                     <TableRow>
-                        <TableCell>
+                        <TableCell sx={{ position: 'sticky', left: 0, zIndex: 3 }}>
                             <Button onClick={addReportDate}>הוסף תאריך חדש</Button>
                         </TableCell>
                         {reportDates.map((date, index) => (
@@ -110,6 +111,16 @@ export const StudentList = ({ reportDates, setReportDates }) => {
                                     )}
                                 </div>
 
+                                {!gradeMode && hasPerDateLessonCountPermission && (
+                                    <NumberInput
+                                        source={`lessonDetails[${index}].howManyLessons`}
+                                        label="מספר שיעורים לתאריך זה"
+                                        helperText="ריק = לפי מספר השיעורים המשותף למעלה"
+                                        validate={[minValue(0), maxValue(1_000_000)]}
+                                        fullWidth
+                                    />
+                                )}
+
                                 {hasLessonSignaturePermission && (
                                     <>
                                         <CommonTimeInput
@@ -135,7 +146,7 @@ export const StudentList = ({ reportDates, setReportDates }) => {
                         ))}
                     </TableRow>
                     <TableRow>
-                        <TableCell>
+                        <TableCell sx={{ position: 'sticky', left: 0, zIndex: 3 }}>
                             <Text>שם התלמידה</Text>
                         </TableCell>
                         {reportDates.map((date, index) =>
@@ -153,7 +164,14 @@ export const StudentList = ({ reportDates, setReportDates }) => {
                             .filter((student) => student.student)
                             .map((student) => (
                                 <TableRow key={student.student.id}>
-                                    <TableCell>
+                                    <TableCell
+                                        sx={{
+                                            position: 'sticky',
+                                            left: 0,
+                                            zIndex: 1,
+                                            backgroundColor: 'background.paper',
+                                        }}
+                                    >
                                         <Text>{student.student.name}</Text>
                                     </TableCell>
                                     {reportDates.map((date, index) => (
@@ -162,7 +180,11 @@ export const StudentList = ({ reportDates, setReportDates }) => {
                                             index={index}
                                             columns={columns}
                                             studentId={student.student.id}
-                                            lessonCount={record.howManyLessons}
+                                            lessonCount={
+                                                (hasPerDateLessonCountPermission &&
+                                                    record.lessonDetails?.[index]?.howManyLessons) ||
+                                                record.howManyLessons
+                                            }
                                         />
                                     ))}
                                 </TableRow>

--- a/client/src/reports/in-lesson-report/StudentList.jsx
+++ b/client/src/reports/in-lesson-report/StudentList.jsx
@@ -80,7 +80,7 @@ export const StudentList = ({ reportDates, setReportDates }) => {
             <Table stickyHeader size="small">
                 <TableHead>
                     <TableRow>
-                        <TableCell sx={{ position: 'sticky', left: 0, zIndex: 3 }}>
+                        <TableCell sx={{ position: 'sticky', insetInlineStart: 0, zIndex: 3 }}>
                             <Button onClick={addReportDate}>הוסף תאריך חדש</Button>
                         </TableCell>
                         {reportDates.map((date, index) => (
@@ -146,7 +146,7 @@ export const StudentList = ({ reportDates, setReportDates }) => {
                         ))}
                     </TableRow>
                     <TableRow>
-                        <TableCell sx={{ position: 'sticky', left: 0, zIndex: 3 }}>
+                        <TableCell sx={{ position: 'sticky', insetInlineStart: 0, zIndex: 3 }}>
                             <Text>שם התלמידה</Text>
                         </TableCell>
                         {reportDates.map((date, index) =>
@@ -167,7 +167,7 @@ export const StudentList = ({ reportDates, setReportDates }) => {
                                     <TableCell
                                         sx={{
                                             position: 'sticky',
-                                            left: 0,
+                                            insetInlineStart: 0,
                                             zIndex: 1,
                                             backgroundColor: 'background.paper',
                                         }}

--- a/client/src/reports/in-lesson-report/index.jsx
+++ b/client/src/reports/in-lesson-report/index.jsx
@@ -100,7 +100,7 @@ export const InLessonReport = ({
                         newEntry.grade = rest[studentId]?.[`grade_${index}`] ?? 0;
                         newEntry.comments = rest[studentId]?.[`comments_${index}`] ?? '';
                     } else {
-                        newEntry.howManyLessons = howManyLessons;
+                        newEntry.howManyLessons = lessonDetails?.[index]?.howManyLessons ?? howManyLessons;
                         newEntry.absCount = round(
                             (rest[studentId]?.[`absence_${index}`] ?? 0) +
                                 (rest[studentId]?.[`late_${index}`] ?? 0) * lateValue,

--- a/client/src/utils/appPermissions.js
+++ b/client/src/utils/appPermissions.js
@@ -16,6 +16,7 @@ export const appPermissions = {
     studentAttendanceByKlass: 'studentAttendanceByKlass',
     seminarAttendanceYemot: 'seminarAttendanceYemot',
     lessonSchedule: 'lessonSchedule',
+    perDateLessonCount: 'perDateLessonCount',
 };
 
 export const isScannerUpload = (permissions) => hasPermissionLogic(permissions, appPermissions.scannerUpload);
@@ -71,3 +72,7 @@ export const useIsSeminarAttendanceYemot = () => useHasPermission(appPermissions
 export const isLessonSchedule = (permissions) =>
     isAdmin(permissions) || hasPermissionLogic(permissions, appPermissions.lessonSchedule);
 export const useIsLessonSchedule = () => useHasPermission(appPermissions.lessonSchedule);
+
+export const isPerDateLessonCount = (permissions) =>
+    isAdmin(permissions) || hasPermissionLogic(permissions, appPermissions.perDateLessonCount);
+export const useIsPerDateLessonCount = () => useHasPermission(appPermissions.perDateLessonCount);

--- a/server/src/reports/reportGroupSessionsSummary.tsx
+++ b/server/src/reports/reportGroupSessionsSummary.tsx
@@ -194,7 +194,7 @@ const SessionsSummaryReport: React.FC<ReportGroupSessionsSummaryData> = (props) 
           <tr>
             <th style={headerStyle}>תאריך</th>
             <th style={headerStyle}>נושא</th>
-            {/* <th style={headerStyle}>שיעור</th> */}
+            <th style={headerStyle}>שיעור</th>
             {!isSingleKlass && <th style={headerStyle}>כיתה</th>}
             <th style={headerStyle}>מספר שיעורים</th>
             <th style={headerStyle}>חתימת מורה</th>
@@ -205,7 +205,7 @@ const SessionsSummaryReport: React.FC<ReportGroupSessionsSummaryData> = (props) 
             <tr key={index}>
               <td style={cellStyle}>{formatDate(session.date)}</td>
               <td style={cellStyle}>{session.topic || '-'}</td>
-              {/* <td style={cellStyle}>{session.lessonName || '-'}</td> */}
+              <td style={cellStyle}>{session.lessonName || '-'}</td>
               {!isSingleKlass && <td style={cellStyle}>{session.klassName || '-'}</td>}
               <td style={cellStyle}>{session.lessonCount}</td>
               <td style={cellStyle}>


### PR DESCRIPTION
Enable teachers with `perDateLessonCount` permission to override lesson count per report date instead of using single global value.

**Changes:**
- Add `perDateLessonCount` permission to `appPermissions` and create `useIsPerDateLessonCount()` hook
- Add `NumberInput` field in report date headers to set `lessonDetails[index].howManyLessons` when permission granted
- Update lesson count logic to use per-date override if available, fallback to global `howManyLessons`
- Make table sticky headers work with horizontal scroll (sticky first column, max-height container)
- Uncomment lesson name column in sessions summary report

**Implementation details:**
- Per-date lesson count stored in `lessonDetails[index].howManyLessons`
- Field only shown when not in grade mode and user has permission
- Validation: min 0, max 1,000,000
- Helper text explains fallback behavior
- Sticky positioning applied to first column (student name) and date header row for better UX with scrolling

https://claude.ai/code/session_01B1NERKv7WYgToYwbg7WGYX