### PR TITLE
Functional test coverage: audit report + client smoke tests + Student CRUD e2e

### DIFF
--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -1,0 +1,39 @@
+# Functional Test Coverage Report
+
+_Assessed 2026-08-11. This is not a code/line coverage report. It asks a different question: for the things a real user does in this app — log in, open a list, fill a form, download a report, call in and report attendance by phone — is there an automated test that actually exercises that behavior?_
+
+## TL;DR
+
+- **Phone (Yemot IVR) attendance reporting is the best-tested feature in the app** — every call flow (transport confirmation, deadline cutoff, seminar attendance, manager report call) has a scenario test.
+- **Report/export generation (Excel, PDF, "michlol" file) is well covered** at the data/business-logic level.
+- **The client (browser UI) has effectively no functional coverage.** There's one smoke test that renders `<App/>` and checks *something* appeared on screen — no entity list, create form, edit form, or button click is ever exercised.
+- **No test anywhere drives a real HTTP request through a real entity CRUD endpoint** (create/list/update/delete a student, teacher, class, etc.). The only HTTP-level ("e2e") test is a boilerplate "GET / returns Hello World" check.
+- Login/auth itself is tested in the shared `nra-server`/`nra-client` libraries this app depends on, so it's inherited "for free" — not a gap specific to this app.
+
+## Coverage by area
+
+| Area | Client (browser) | Server (API / business logic) | Verdict |
+|---|---|---|---|
+| Phone attendance reporting (Yemot) | n/a | Every call-flow branch scenario-tested (`yemot-handler.service.test.ts`) | ✅ Strong |
+| Report/export generation (Excel, PDF, michlol file) | Not applicable (triggered server-side) | `reportGenerator.spec.ts`, `michlolPopulatedFile.spec.ts`, `teacherReportFile.spec.ts`, `studentReportData.util.spec.ts` | ✅ Strong |
+| Entity business logic (custom export headers, computed fields, per-entity services) | — | 20 entity-config spec files exercise these, but against mocked repos, not a real DB/HTTP call | 🟡 Partial |
+| Entity CRUD screens (Student, Teacher, Klass, AttReport, Grade, …) — actually opening a list, submitting a create/edit form | None | None (no HTTP-level CRUD test for any entity) | 🔴 Gap |
+| Login / permissions | Inherited from shared libraries (`nra-client`/`nra-server`) | Inherited from shared libraries | 🟢 Covered elsewhere, no action needed |
+
+## What's genuinely covered
+
+- **`server/src/yemot-handler.service.test.ts`** — this is a real functional test suite for the phone-based attendance flow teachers use daily: past-deadline hangups, transport confirmation happy/error paths, seminar attendance (with and without signature permission), "already reported today" guards, and the manager's daily report call. If this suite is green, the phone flow genuinely works.
+- **`server/src/reports/__tests__/`** — Excel/PDF/michlol report generation is tested against realistic data, so a broken report layout or missing field would be caught.
+- **`server/src/entity-modules/__tests__/*.config.spec.ts`** — covers custom business logic living in entity configs (e.g. `StudentConfig`'s report-type routing), but only at the service level with a mocked repository. It proves the logic is correct in isolation, not that the API endpoint built on top of it works end to end.
+
+## What's not covered / at risk
+
+1. **Client UI has one test in the whole app**: `client/src/App.test.js` renders `<App/>` and asserts *any* element exists. No List, Create, or Edit screen for any of the 24 client entities (Student, Teacher, Klass, AttReport, Grade, Transportation, …) is ever rendered in a test. A broken field, a crashing form, or a bad filter would only be caught by a human clicking through the app.
+   - Note: the shared `nra-client` library ships a ready-made `createResourceTests` helper (a generic smoke test that renders every registered resource and confirms the page loads) — it exists but this app never calls it. Wiring it in would be the highest-value, lowest-effort fix here.
+2. **No real HTTP CRUD test.** `server/test/app.e2e-spec.ts` only calls the shared `createSharedAppE2eTests`, which checks that the app boots on SQLite in-memory and `GET /` returns "Hello World!". No test creates a student via `POST /student`, lists teachers via `GET /teacher`, or checks that a filter/permission is enforced over real HTTP.
+3. **Bulk actions and admin-only screens** (grade entry, report-group sessions, teacher salary report) have no test above the config/service layer — same gap as #1 and #2.
+
+## Test inventory (what was reviewed)
+
+- Server: `server/src/__tests__/entities.module.spec.ts`, `server/src/entity-modules/__tests__/*.config.spec.ts` (20 files), `server/src/reports/__tests__/*.spec.ts` (3 files), `server/src/utils/__tests__/studentReportData.util.spec.ts`, `server/src/yemot-handler.service.test.ts`, `server/test/app.e2e-spec.ts`.
+- Client: `client/src/App.test.js` (only client test in the project).

--- a/TEST_COVERAGE.md
+++ b/TEST_COVERAGE.md
@@ -6,8 +6,8 @@ _Assessed 2026-08-11. This is not a code/line coverage report. It asks a differe
 
 - **Phone (Yemot IVR) attendance reporting is the best-tested feature in the app** — every call flow (transport confirmation, deadline cutoff, seminar attendance, manager report call) has a scenario test.
 - **Report/export generation (Excel, PDF, "michlol" file) is well covered** at the data/business-logic level.
-- **The client (browser UI) has effectively no functional coverage.** There's one smoke test that renders `<App/>` and checks *something* appeared on screen — no entity list, create form, edit form, or button click is ever exercised.
-- **No test anywhere drives a real HTTP request through a real entity CRUD endpoint** (create/list/update/delete a student, teacher, class, etc.). The only HTTP-level ("e2e") test is a boilerplate "GET / returns Hello World" check.
+- ✅ **Client resource smoke tests and a Student CRUD e2e pilot have since been added** (see "What's genuinely covered").
+- **The client (browser UI) still has thin functional coverage** — the new smoke test confirms every resource list page renders, but no create/edit form, or button click is ever exercised.
 - Login/auth itself is tested in the shared `nra-server`/`nra-client` libraries this app depends on, so it's inherited "for free" — not a gap specific to this app.
 
 ## Coverage by area
@@ -17,7 +17,9 @@ _Assessed 2026-08-11. This is not a code/line coverage report. It asks a differe
 | Phone attendance reporting (Yemot) | n/a | Every call-flow branch scenario-tested (`yemot-handler.service.test.ts`) | ✅ Strong |
 | Report/export generation (Excel, PDF, michlol file) | Not applicable (triggered server-side) | `reportGenerator.spec.ts`, `michlolPopulatedFile.spec.ts`, `teacherReportFile.spec.ts`, `studentReportData.util.spec.ts` | ✅ Strong |
 | Entity business logic (custom export headers, computed fields, per-entity services) | — | 20 entity-config spec files exercise these, but against mocked repos, not a real DB/HTTP call | 🟡 Partial |
-| Entity CRUD screens (Student, Teacher, Klass, AttReport, Grade, …) — actually opening a list, submitting a create/edit form | None | None (no HTTP-level CRUD test for any entity) | 🔴 Gap |
+| Entity list pages render (all 24 entities) | ✅ `client/src/entities.test.js` (added) | — | ✅ Covered |
+| Entity CRUD over real HTTP | — | ✅ Student: create/list/update/delete (`server/test/student-crud.e2e-spec.ts`, added); other 23 entities: none | 🟡 Partial (1 of 24) |
+| Entity Create/Edit forms (fill + submit in a browser-level test) | None | — | 🔴 Gap |
 | Login / permissions | Inherited from shared libraries (`nra-client`/`nra-server`) | Inherited from shared libraries | 🟢 Covered elsewhere, no action needed |
 
 ## What's genuinely covered
@@ -25,15 +27,16 @@ _Assessed 2026-08-11. This is not a code/line coverage report. It asks a differe
 - **`server/src/yemot-handler.service.test.ts`** — this is a real functional test suite for the phone-based attendance flow teachers use daily: past-deadline hangups, transport confirmation happy/error paths, seminar attendance (with and without signature permission), "already reported today" guards, and the manager's daily report call. If this suite is green, the phone flow genuinely works.
 - **`server/src/reports/__tests__/`** — Excel/PDF/michlol report generation is tested against realistic data, so a broken report layout or missing field would be caught.
 - **`server/src/entity-modules/__tests__/*.config.spec.ts`** — covers custom business logic living in entity configs (e.g. `StudentConfig`'s report-type routing), but only at the service level with a mocked repository. It proves the logic is correct in isolation, not that the API endpoint built on top of it works end to end.
+- **`client/src/entities.test.js`** (added) — wires the shared `createResourceTests` helper; renders every registered resource's list page and confirms it loads without crashing.
+- **`server/test/student-crud.e2e-spec.ts`** (added) — real HTTP create/list/update/delete lifecycle for Student, against the in-memory test DB (not a mocked repo).
 
 ## What's not covered / at risk
 
-1. **Client UI has one test in the whole app**: `client/src/App.test.js` renders `<App/>` and asserts *any* element exists. No List, Create, or Edit screen for any of the 24 client entities (Student, Teacher, Klass, AttReport, Grade, Transportation, …) is ever rendered in a test. A broken field, a crashing form, or a bad filter would only be caught by a human clicking through the app.
-   - Note: the shared `nra-client` library ships a ready-made `createResourceTests` helper (a generic smoke test that renders every registered resource and confirms the page loads) — it exists but this app never calls it. Wiring it in would be the highest-value, lowest-effort fix here.
-2. **No real HTTP CRUD test.** `server/test/app.e2e-spec.ts` only calls the shared `createSharedAppE2eTests`, which checks that the app boots on SQLite in-memory and `GET /` returns "Hello World!". No test creates a student via `POST /student`, lists teachers via `GET /teacher`, or checks that a filter/permission is enforced over real HTTP.
+1. **Create/Edit forms are still unverified.** The client smoke test confirms list pages render; no test fills in and submits a Create or Edit form for any of the 24 entities. A broken field or crashing form would only be caught by a human clicking through the app.
+2. **CRUD e2e covers only 1 of 24 entities** (Student). The other 23 (Teacher, Klass, AttReport, Grade, Transportation, …) still have no HTTP-level test.
 3. **Bulk actions and admin-only screens** (grade entry, report-group sessions, teacher salary report) have no test above the config/service layer — same gap as #1 and #2.
 
 ## Test inventory (what was reviewed)
 
-- Server: `server/src/__tests__/entities.module.spec.ts`, `server/src/entity-modules/__tests__/*.config.spec.ts` (20 files), `server/src/reports/__tests__/*.spec.ts` (3 files), `server/src/utils/__tests__/studentReportData.util.spec.ts`, `server/src/yemot-handler.service.test.ts`, `server/test/app.e2e-spec.ts`.
-- Client: `client/src/App.test.js` (only client test in the project).
+- Server: `server/src/__tests__/entities.module.spec.ts`, `server/src/entity-modules/__tests__/*.config.spec.ts` (20 files), `server/src/reports/__tests__/*.spec.ts` (3 files), `server/src/utils/__tests__/studentReportData.util.spec.ts`, `server/src/yemot-handler.service.test.ts`, `server/test/app.e2e-spec.ts`, `server/test/student-crud.e2e-spec.ts` (added).
+- Client: `client/src/App.test.js`, `client/src/entities.test.js` (added).

--- a/client/src/entities.test.js
+++ b/client/src/entities.test.js
@@ -1,0 +1,5 @@
+// Smoke-tests every React Admin resource page registered in this app's App.
+import { createResourceTests } from '@shared/utils/testing/createResourceTests';
+import App from 'src/App';
+
+createResourceTests(App);

--- a/server/test/student-crud.e2e-spec.ts
+++ b/server/test/student-crud.e2e-spec.ts
@@ -1,0 +1,73 @@
+import '@shared/config/crud.config';
+import * as cookieParser from 'cookie-parser';
+import { Test } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+import { AppModule } from 'src/app.module';
+import { HttpTestUtils } from '@shared/utils/testing/e2e/test-utils';
+
+describe('student CRUD (e2e)', () => {
+  let app: INestApplication;
+  let dataSource: DataSource;
+  let httpUtils: HttpTestUtils;
+  let cookie: string;
+
+  beforeAll(async () => {
+    const moduleFixture = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    app = moduleFixture.createNestApplication();
+    app.use(cookieParser());
+    await app.init();
+    dataSource = moduleFixture.get(DataSource);
+    httpUtils = new HttpTestUtils(app);
+
+    const registerRes = await httpUtils
+      .post('/auth/register', { username: 'e2e_student_user', password: 'TestPass_123', name: 'E2E' })
+      .expect(200);
+    cookie = registerRes.headers['set-cookie'][0].match(/Authentication=[^;]+/)[0];
+  });
+
+  afterAll(async () => {
+    if (dataSource?.isInitialized) {
+      await dataSource.destroy();
+    }
+    await app.close();
+  });
+
+  it('runs a full create -> list -> update -> delete lifecycle over real HTTP', async () => {
+    // Create
+    const createRes = await httpUtils
+      .post('/student', { tz: '123456789', name: 'תלמידה בדיקה' })
+      .set('Cookie', cookie)
+      .expect(201);
+    const studentId = createRes.body.id;
+    expect(studentId).toBeDefined();
+    expect(createRes.body).toEqual(expect.objectContaining({ tz: '123456789', name: 'תלמידה בדיקה' }));
+
+    // List
+    const listRes = await httpUtils
+      .get(`/student?filter[0]=tz||$eq||123456789`)
+      .set('Cookie', cookie)
+      .expect(200);
+    expect(listRes.body.some((s: any) => s.id === studentId)).toBe(true);
+
+    // Update
+    const updateRes = await httpUtils
+      .patch(`/student/${studentId}`, { name: 'תלמידה מעודכנת' })
+      .set('Cookie', cookie)
+      .expect(200);
+    expect(updateRes.body).toEqual(expect.objectContaining({ id: studentId, name: 'תלמידה מעודכנת' }));
+
+    const getAfterUpdateRes = await httpUtils.get(`/student/${studentId}`).set('Cookie', cookie).expect(200);
+    expect(getAfterUpdateRes.body.name).toBe('תלמידה מעודכנת');
+
+    // Delete
+    await httpUtils.delete(`/student/${studentId}`).set('Cookie', cookie).expect(200);
+
+    await httpUtils.get(`/student/${studentId}`).set('Cookie', cookie).expect(404);
+  });
+
+  it('rejects creating a student without the required fields', async () => {
+    const res = await httpUtils.post('/student', {}).set('Cookie', cookie);
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/test/student-crud.e2e-spec.ts
+++ b/server/test/student-crud.e2e-spec.ts
@@ -1,19 +1,25 @@
 import '@shared/config/crud.config';
 import * as cookieParser from 'cookie-parser';
-import { Test } from '@nestjs/testing';
+import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import { DataSource } from 'typeorm';
 import { AppModule } from 'src/app.module';
 import { HttpTestUtils } from '@shared/utils/testing/e2e/test-utils';
+
+// The CRUD list endpoint returns a plain array by default, or a paginated
+// { data: [...] } object once pagination kicks in (e.g. a page/limit query param).
+// Normalize so list assertions below don't depend on which shape came back.
+const asList = (body: any): any[] => (Array.isArray(body) ? body : body.data);
 
 describe('student CRUD (e2e)', () => {
   let app: INestApplication;
   let dataSource: DataSource;
   let httpUtils: HttpTestUtils;
   let cookie: string;
+  let moduleFixture: TestingModule;
 
   beforeAll(async () => {
-    const moduleFixture = await Test.createTestingModule({ imports: [AppModule] }).compile();
+    moduleFixture = await Test.createTestingModule({ imports: [AppModule] }).compile();
     app = moduleFixture.createNestApplication();
     app.use(cookieParser());
     await app.init();
@@ -23,14 +29,20 @@ describe('student CRUD (e2e)', () => {
     const registerRes = await httpUtils
       .post('/auth/register', { username: 'e2e_student_user', password: 'TestPass_123', name: 'E2E' })
       .expect(200);
-    cookie = registerRes.headers['set-cookie'][0].match(/Authentication=[^;]+/)[0];
+    const setCookieHeader = registerRes.headers['set-cookie'];
+    const authCookie = setCookieHeader?.[0]?.match(/Authentication=[^;]+/)?.[0];
+    if (!authCookie) {
+      throw new Error(`Expected an Authentication cookie from /auth/register, got Set-Cookie: ${JSON.stringify(setCookieHeader)}`);
+    }
+    cookie = authCookie;
   });
 
   afterAll(async () => {
     if (dataSource?.isInitialized) {
       await dataSource.destroy();
     }
-    await app.close();
+    await app?.close();
+    await moduleFixture?.close();
   });
 
   it('runs a full create -> list -> update -> delete lifecycle over real HTTP', async () => {
@@ -48,7 +60,7 @@ describe('student CRUD (e2e)', () => {
       .get(`/student?filter[0]=tz||$eq||123456789`)
       .set('Cookie', cookie)
       .expect(200);
-    expect(listRes.body.some((s: any) => s.id === studentId)).toBe(true);
+    expect(asList(listRes.body).some((s: any) => s.id === studentId)).toBe(true);
 
     // Update
     const updateRes = await httpUtils


### PR DESCRIPTION
## Summary

Functional test coverage audit for this app, plus the highest-value gaps closed.

- **`TEST_COVERAGE.md`** — audits what user-facing functionality (not lines/functions) is actually exercised by automated tests, client and server, with gaps called out explicitly.
- **`client/src/entities.test.js`** — wires the shared `nra-client` `createResourceTests` helper against this app's `App`, smoke-testing every registered resource's list page. Previously the only client test was a one-line `<App/>` render check.
- **`server/test/student-crud.e2e-spec.ts`** — pilot HTTP-level e2e for Student: create → list → update → delete over real HTTP against the in-memory test DB. Previously the only "e2e" test was a boilerplate `GET / → Hello World` check.

## Testing

- `cd server && yarn test` — 97 suites / 919 tests pass
- `cd server && yarn test:e2e` — 2 suites / 4 tests pass
- `cd client && yarn test` — 29 suites / 192 tests pass

No app code changes were needed — everything passed on first correct run.

---
_Generated by [Claude Code](https://claude.ai/code/session_017YepEQ4PfrEhS2L8imLLRe)_