### PR TITLE
Bump server/shared: adopt shared e2e test helpers in Student CRUD spec

### DIFF
--- a/server/test/student-crud.e2e-spec.ts
+++ b/server/test/student-crud.e2e-spec.ts
@@ -1,48 +1,26 @@
 import '@shared/config/crud.config';
-import * as cookieParser from 'cookie-parser';
-import { Test, TestingModule } from '@nestjs/testing';
-import { INestApplication } from '@nestjs/common';
-import { DataSource } from 'typeorm';
+import { createTestApp, TestAppHelper } from '@shared/utils/testing/e2e/test-app.helper';
+import { HttpTestUtils, registerAndAuthenticate, asList } from '@shared/utils/testing/e2e/test-utils';
 import { AppModule } from 'src/app.module';
-import { HttpTestUtils } from '@shared/utils/testing/e2e/test-utils';
-
-// The CRUD list endpoint returns a plain array by default, or a paginated
-// { data: [...] } object once pagination kicks in (e.g. a page/limit query param).
-// Normalize so list assertions below don't depend on which shape came back.
-const asList = (body: any): any[] => (Array.isArray(body) ? body : body.data);
 
 describe('student CRUD (e2e)', () => {
-  let app: INestApplication;
-  let dataSource: DataSource;
+  let testApp: TestAppHelper;
   let httpUtils: HttpTestUtils;
   let cookie: string;
-  let moduleFixture: TestingModule;
 
   beforeAll(async () => {
-    moduleFixture = await Test.createTestingModule({ imports: [AppModule] }).compile();
-    app = moduleFixture.createNestApplication();
-    app.use(cookieParser());
-    await app.init();
-    dataSource = moduleFixture.get(DataSource);
+    testApp = createTestApp(AppModule);
+    const app = await testApp.initializeApp();
     httpUtils = new HttpTestUtils(app);
-
-    const registerRes = await httpUtils
-      .post('/auth/register', { username: 'e2e_student_user', password: 'TestPass_123', name: 'E2E' })
-      .expect(200);
-    const setCookieHeader = registerRes.headers['set-cookie'];
-    const authCookie = setCookieHeader?.[0]?.match(/Authentication=[^;]+/)?.[0];
-    if (!authCookie) {
-      throw new Error(`Expected an Authentication cookie from /auth/register, got Set-Cookie: ${JSON.stringify(setCookieHeader)}`);
-    }
-    cookie = authCookie;
+    cookie = await registerAndAuthenticate(httpUtils, {
+      username: 'e2e_student_user',
+      password: 'TestPass_123',
+      name: 'E2E',
+    });
   });
 
   afterAll(async () => {
-    if (dataSource?.isInitialized) {
-      await dataSource.destroy();
-    }
-    await app?.close();
-    await moduleFixture?.close();
+    await testApp.cleanup();
   });
 
   it('runs a full create -> list -> update -> delete lifecycle over real HTTP', async () => {

--- a/server/test/student-crud.e2e-spec.ts
+++ b/server/test/student-crud.e2e-spec.ts
@@ -20,7 +20,7 @@ describe('student CRUD (e2e)', () => {
   });
 
   afterAll(async () => {
-    await testApp.cleanup();
+    await testApp?.cleanup();
   });
 
   it('runs a full create -> list -> update -> delete lifecycle over real HTTP', async () => {


### PR DESCRIPTION
## Summary

Bumps `server/shared` to pick up `nra-server`'s new e2e test helpers (`registerAndAuthenticate()`, `asList()`, `TestAppHelper` now wiring `cookie-parser` itself — see `nra-server` [PR #33](https://github.com/buzz-code/nra-server/pull/33), merged) and swaps `server/test/student-crud.e2e-spec.ts` to use them, per the `CONSUMER_CHANGES.md` row for commit `28a61f5`.

Drops the hand-rolled `Test.createTestingModule`/cookie-parser/cookie-regex/teardown boilerplate that was duplicated across all 5 apps' CRUD e2e specs — 73 lines → 56, same behavior.

## Testing

- `cd server && yarn test:e2e` — 2 suites / 4 tests pass
- `cd server && yarn test` — 97 suites / 919 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_017YepEQ4PfrEhS2L8imLLRe)_